### PR TITLE
ci: update build and upload workflows to extract version without 'v' …

### DIFF
--- a/.github/workflows/deployment-to-dev.yml
+++ b/.github/workflows/deployment-to-dev.yml
@@ -62,16 +62,26 @@ jobs:
         id: set_output
         run: echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
-  build:
+  extract-version:
     needs: versioning
+    runs-on: ubuntu-latest
+    outputs:
+      version_without_v: ${{ steps.strip_v.outputs.version_without_v }}
+    steps:
+      - name: Strip 'v' prefix from version
+        id: strip_v
+        run: echo "version_without_v=$(echo ${{ needs.versioning.outputs.new_version }} | sed 's/^v//')" >> $GITHUB_OUTPUT
+
+  build:
+    needs: [versioning, extract-version]
     uses: ./.github/workflows/build.yml
     with:
-      version: ${{ needs.versioning.outputs.new_version }}
+      version: ${{ needs.extract-version.outputs.version_without_v }}
 
   upload:
-    needs: build
+    needs: [build, extract-version]
     uses: ./.github/workflows/upload-to-r2.yml
     with:
-      version: ${{ needs.versioning.outputs.new_version }}
+      version: ${{ needs.extract-version.outputs.version_without_v }}
       package_name: hyphen-cli-dev
     secrets: inherit

--- a/.github/workflows/deployment-to-prod.yml
+++ b/.github/workflows/deployment-to-prod.yml
@@ -6,16 +6,25 @@ on:
       - published
 
 jobs:
+  extract-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - name: Extract version without 'v' prefix
+        id: get_version
+        run: echo "version=$(echo ${{ github.ref_name }} | sed 's/^v//')" >> $GITHUB_OUTPUT
+
   build:
+    needs: extract-version
     uses: ./.github/workflows/build.yml
     with:
-      version: ${{ github.ref_name }}
+      version: ${{ needs.extract-version.outputs.version }}
 
   upload:
-    needs: build
+    needs: [extract-version, build]
     uses: ./.github/workflows/upload-to-r2.yml
     with:
-      version: ${{ github.ref_name }}
+      version: ${{ needs.extract-version.outputs.version }}
       package_name: hyphen-cli
     secrets: inherit
-


### PR DESCRIPTION
…prefix

In this commit, we have updated the build and upload steps in deployment-to-dev.yml and deployment-to-prod.yml workflows. We have added a new 'extract-version' job, which strips the 'v' prefix from the version. This stripped version is then used in subsequent build and upload steps.