### PR TITLE
refactor: adding aouth token extraction logic in an http client

### DIFF
--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -6,9 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"time"
 
-	"github.com/Hyphen/cli/internal/oauth"
 	"github.com/Hyphen/cli/pkg/conf"
 	"github.com/Hyphen/cli/pkg/errors"
 	"github.com/Hyphen/cli/pkg/httputil"
@@ -22,28 +20,19 @@ type AppServicer interface {
 }
 
 type AppService struct {
-	baseUrl      string
-	oauthService oauth.OAuthServicer
-	httpClient   httputil.Client
+	baseUrl    string
+	httpClient httputil.Client
 }
 
 func NewService() *AppService {
 	baseUrl := conf.GetBaseApixUrl()
 	return &AppService{
-		baseUrl:      baseUrl,
-		oauthService: oauth.DefaultOAuthService(),
-		httpClient: &http.Client{
-			Timeout: time.Second * 30,
-		},
+		baseUrl:    baseUrl,
+		httpClient: httputil.NewHyphenHTTPClient(),
 	}
 }
 
 func (ps *AppService) GetListApps(organizationID string, pageSize, pageNum int) ([]App, error) {
-	token, err := ps.oauthService.GetValidToken()
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to authenticate. Please check your credentials and try again.")
-	}
-
 	url := fmt.Sprintf("%s/api/organizations/%s/projects/?pageNum=%d&pageSize=%d", ps.baseUrl, organizationID, pageNum, pageSize)
 
 	req, err := http.NewRequest("GET", url, nil)
@@ -51,12 +40,9 @@ func (ps *AppService) GetListApps(organizationID string, pageSize, pageNum int) 
 		return nil, errors.Wrap(err, "Failed to create request")
 	}
 
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/json")
-
 	resp, err := ps.httpClient.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to send request")
+		return nil, err
 	}
 	defer resp.Body.Close()
 
@@ -85,11 +71,6 @@ func (ps *AppService) GetListApps(organizationID string, pageSize, pageNum int) 
 }
 
 func (ps *AppService) CreateApp(organizationID, alternateID, name string) (App, error) {
-	token, err := ps.oauthService.GetValidToken()
-	if err != nil {
-		return App{}, errors.Wrap(err, "Failed to authenticate. Please check your credentials and try again.")
-	}
-
 	url := fmt.Sprintf("%s/api/organizations/%s/projects/", ps.baseUrl, organizationID)
 
 	payload := struct {
@@ -110,13 +91,9 @@ func (ps *AppService) CreateApp(organizationID, alternateID, name string) (App, 
 		return App{}, errors.Wrap(err, "Failed to create request")
 	}
 
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-
 	resp, err := ps.httpClient.Do(req)
 	if err != nil {
-		return App{}, errors.Wrap(err, "Failed to send request")
+		return App{}, err
 	}
 	defer resp.Body.Close()
 
@@ -139,11 +116,6 @@ func (ps *AppService) CreateApp(organizationID, alternateID, name string) (App, 
 }
 
 func (ps *AppService) GetApp(organizationID, appID string) (App, error) {
-	token, err := ps.oauthService.GetValidToken()
-	if err != nil {
-		return App{}, errors.Wrap(err, "Failed to authenticate. Please check your credentials and try again.")
-	}
-
 	url := fmt.Sprintf("%s/api/organizations/%s/projects/%s/", ps.baseUrl, organizationID, appID)
 
 	req, err := http.NewRequest("GET", url, nil)
@@ -151,12 +123,9 @@ func (ps *AppService) GetApp(organizationID, appID string) (App, error) {
 		return App{}, errors.Wrap(err, "Failed to create request")
 	}
 
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/json")
-
 	resp, err := ps.httpClient.Do(req)
 	if err != nil {
-		return App{}, errors.Wrap(err, "Failed to send request")
+		return App{}, err
 	}
 	defer resp.Body.Close()
 
@@ -179,11 +148,6 @@ func (ps *AppService) GetApp(organizationID, appID string) (App, error) {
 }
 
 func (ps *AppService) DeleteApp(organizationID, appID string) error {
-	token, err := ps.oauthService.GetValidToken()
-	if err != nil {
-		return errors.Wrap(err, "Failed to authenticate. Please check your credentials and try again.")
-	}
-
 	url := fmt.Sprintf("%s/api/organizations/%s/projects/%s/", ps.baseUrl, organizationID, appID)
 
 	req, err := http.NewRequest("DELETE", url, nil)
@@ -191,11 +155,9 @@ func (ps *AppService) DeleteApp(organizationID, appID string) error {
 		return errors.Wrap(err, "Failed to create request")
 	}
 
-	req.Header.Set("Authorization", "Bearer "+token)
-
 	resp, err := ps.httpClient.Do(req)
 	if err != nil {
-		return errors.Wrap(err, "Failed to send request")
+		return err
 	}
 	defer resp.Body.Close()
 

--- a/internal/user/service.go
+++ b/internal/user/service.go
@@ -4,9 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"time"
 
-	"github.com/Hyphen/cli/internal/oauth"
 	"github.com/Hyphen/cli/pkg/conf"
 	"github.com/Hyphen/cli/pkg/errors"
 	"github.com/Hyphen/cli/pkg/httputil"
@@ -17,39 +15,28 @@ type UserServicer interface {
 }
 
 type UserService struct {
-	baseUrl      string
-	oauthService oauth.OAuthServicer
-	client       httputil.Client
+	baseUrl string
+	client  httputil.Client
 }
 
 func NewService() UserServicer {
 	baseUrl := conf.GetBaseApixUrl()
 	return &UserService{
-		baseUrl:      baseUrl,
-		oauthService: oauth.DefaultOAuthService(),
-		client: &http.Client{
-			Timeout: time.Second * 30,
-		},
+		baseUrl: baseUrl,
+		client:  httputil.NewHyphenHTTPClient(),
 	}
 }
 
 func (us *UserService) GetUserInformation() (UserInfo, error) {
-	token, err := us.oauthService.GetValidToken()
-	if err != nil {
-		return UserInfo{}, errors.Wrap(err, "Failed to authenticate. Please check your credentials and try again.")
-	}
 
 	req, err := http.NewRequest("GET", us.baseUrl+"/api/me/", nil)
 	if err != nil {
 		return UserInfo{}, errors.Wrap(err, "Failed to prepare the request. Please try again later.")
 	}
 
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
-
 	resp, err := us.client.Do(req)
 	if err != nil {
-		return UserInfo{}, errors.Wrap(err, "Failed to connect to the server. Please check your internet connection and try again.")
+		return UserInfo{}, err
 	}
 	defer resp.Body.Close()
 

--- a/internal/user/service_test.go
+++ b/internal/user/service_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Hyphen/cli/internal/oauth"
 	"github.com/Hyphen/cli/pkg/errors"
 	"github.com/Hyphen/cli/pkg/httputil"
 	"github.com/stretchr/testify/assert"
@@ -18,14 +17,13 @@ import (
 func TestUserService_GetUserInformation(t *testing.T) {
 	tests := []struct {
 		name           string
-		setupMocks     func(*oauth.MockOAuthService, *httputil.MockHTTPClient)
+		setupMocks     func(*httputil.MockHTTPClient)
 		expectedError  string
 		expectedUserID string
 	}{
 		{
 			name: "Successful request",
-			setupMocks: func(mos *oauth.MockOAuthService, mhc *httputil.MockHTTPClient) {
-				mos.On("GetValidToken").Return("valid_token", nil)
+			setupMocks: func(mhc *httputil.MockHTTPClient) {
 				userInfo := UserInfo{
 					DecodedIdToken: TokenInfo{
 						Sub: "test_user_id",
@@ -40,24 +38,15 @@ func TestUserService_GetUserInformation(t *testing.T) {
 			expectedUserID: "test_user_id",
 		},
 		{
-			name: "OAuth token error",
-			setupMocks: func(mos *oauth.MockOAuthService, mhc *httputil.MockHTTPClient) {
-				mos.On("GetValidToken").Return("", errors.New("OAuth error"))
-			},
-			expectedError: "Failed to authenticate. Please check your credentials and try again.",
-		},
-		{
 			name: "HTTP request error",
-			setupMocks: func(mos *oauth.MockOAuthService, mhc *httputil.MockHTTPClient) {
-				mos.On("GetValidToken").Return("valid_token", nil)
+			setupMocks: func(mhc *httputil.MockHTTPClient) {
 				mhc.On("Do", mock.Anything).Return((*http.Response)(nil), errors.New("HTTP error"))
 			},
-			expectedError: "Failed to connect to the server. Please check your internet connection and try again.",
+			expectedError: "HTTP error",
 		},
 		{
 			name: "Non-200 status code",
-			setupMocks: func(mos *oauth.MockOAuthService, mhc *httputil.MockHTTPClient) {
-				mos.On("GetValidToken").Return("valid_token", nil)
+			setupMocks: func(mhc *httputil.MockHTTPClient) {
 				mhc.On("Do", mock.Anything).Return(&http.Response{
 					StatusCode: http.StatusBadRequest,
 					Body:       io.NopCloser(bytes.NewReader([]byte("Bad Request"))),
@@ -67,8 +56,7 @@ func TestUserService_GetUserInformation(t *testing.T) {
 		},
 		{
 			name: "Invalid JSON response",
-			setupMocks: func(mos *oauth.MockOAuthService, mhc *httputil.MockHTTPClient) {
-				mos.On("GetValidToken").Return("valid_token", nil)
+			setupMocks: func(mhc *httputil.MockHTTPClient) {
 				mhc.On("Do", mock.Anything).Return(&http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte("invalid json"))),
@@ -80,14 +68,12 @@ func TestUserService_GetUserInformation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockOAuth := new(oauth.MockOAuthService)
 			mockHTTP := new(httputil.MockHTTPClient)
-			tt.setupMocks(mockOAuth, mockHTTP)
+			tt.setupMocks(mockHTTP)
 
 			us := &UserService{
-				baseUrl:      "https://test-api.hyphen.ai",
-				oauthService: mockOAuth,
-				client:       mockHTTP,
+				baseUrl: "https://test-api.hyphen.ai",
+				client:  mockHTTP,
 			}
 
 			userInfo, err := us.GetUserInformation()
@@ -99,7 +85,6 @@ func TestUserService_GetUserInformation(t *testing.T) {
 				assert.Equal(t, tt.expectedUserID, userInfo.DecodedIdToken.Sub)
 			}
 
-			mockOAuth.AssertExpectations(t)
 			mockHTTP.AssertExpectations(t)
 		})
 	}

--- a/pkg/httputil/client.go
+++ b/pkg/httputil/client.go
@@ -1,7 +1,45 @@
 package httputil
 
-import "net/http"
+import (
+	"net/http"
+	"time"
+
+	"github.com/Hyphen/cli/internal/oauth"
+	"github.com/Hyphen/cli/pkg/errors"
+)
 
 type Client interface {
 	Do(req *http.Request) (*http.Response, error)
+}
+
+type HyphenClient struct {
+	client       *http.Client
+	oauthService oauth.OAuthServicer
+}
+
+func NewHyphenHTTPClient() *HyphenClient {
+	return &HyphenClient{
+		client: &http.Client{
+			Timeout: time.Second * 30,
+		},
+		oauthService: oauth.DefaultOAuthService(),
+	}
+}
+
+func (hc *HyphenClient) Do(req *http.Request) (*http.Response, error) {
+	token, err := hc.oauthService.GetValidToken()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to authenticate. Please check your credentials and try again.")
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := hc.client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "Request failed")
+	}
+
+	return resp, nil
 }


### PR DESCRIPTION
This will allow you to check if to use the OAuth token or the API key, in one place instead of all over the place