### PR TITLE
feat: Add set-project functionality to CLI

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Hyphen/cli/cmd/pull"
 	"github.com/Hyphen/cli/cmd/push"
 	"github.com/Hyphen/cli/cmd/setorg"
+	"github.com/Hyphen/cli/cmd/setproject"
 	"github.com/Hyphen/cli/cmd/update"
 	"github.com/Hyphen/cli/cmd/version"
 	"github.com/Hyphen/cli/pkg/flags"
@@ -30,6 +31,7 @@ func init() {
 	rootCmd.AddCommand(initialize.InitCmd)
 	rootCmd.AddCommand(auth.AuthCmd)
 	rootCmd.AddCommand(setorg.SetOrgCmd)
+	rootCmd.AddCommand(setproject.SetProjectCmd)
 	rootCmd.AddCommand(pull.PullCmd)
 	rootCmd.AddCommand(push.PushCmd)
 	rootCmd.AddCommand(link.LinkCmd)

--- a/cmd/setproject/setproject.go
+++ b/cmd/setproject/setproject.go
@@ -1,0 +1,33 @@
+package setproject
+
+import (
+	"fmt"
+
+	"github.com/Hyphen/cli/internal/manifest"
+	"github.com/Hyphen/cli/pkg/cprint"
+	"github.com/spf13/cobra"
+)
+
+var SetProjectCmd = &cobra.Command{
+	Use:   "set-project <id>",
+	Short: "Set the project ID",
+	Long:  `Set the project ID for the Hyphen CLI to use.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectID := args[0]
+		err := manifest.UpsertProjectID(projectID)
+		if err != nil {
+			return fmt.Errorf("failed to update project ID: %w", err)
+		}
+		printProjectUpdateSuccess(projectID)
+		return nil
+	},
+}
+
+func printProjectUpdateSuccess(projectID string) {
+	cprint.PrintHeader("--- Project Update ---")
+	cprint.Success("Successfully updated project ID")
+	cprint.PrintDetail("New Project ID", projectID)
+	fmt.Println()
+	cprint.GreenPrint("Hyphen CLI is now set to use the new project.")
+}


### PR DESCRIPTION
This commit introduces a new subcommand set-project <id> to the CLI. This allows users to set the project ID that the Hyphen CLI will use. This command provides additional flexibility to users to switch between different projects as needed.

The implementation involves a new setproject package introducing the set-project cobra command. Also, a new function UpsertProjectID has been added to the manifest package to support updating the project ID. Further, necessary changes have been made to the root.go to import and register the set-project command into the CLI's root command.