### PR TITLE
feat: add global flag for setting organization and project IDs

### DIFF
--- a/cmd/setorg/setorg.go
+++ b/cmd/setorg/setorg.go
@@ -8,6 +8,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	globalFlag bool
+)
+
 var SetOrgCmd = &cobra.Command{
 	Use:   "set-org <id>",
 	Short: "Set the organization ID",
@@ -15,19 +19,38 @@ var SetOrgCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		orgID := args[0]
-		err := manifest.UpsertOrganizationID(orgID)
+		var err error
+
+		if globalFlag {
+			err = manifest.UpsertGlobalOrganizationId(orgID)
+		} else {
+			err = manifest.UpsertOrganizationID(orgID)
+		}
+
 		if err != nil {
 			return fmt.Errorf("failed to update organization ID: %w", err)
 		}
-		printOrgUpdateSuccess(orgID)
+		printOrgUpdateSuccess(orgID, globalFlag)
 		return nil
 	},
 }
 
-func printOrgUpdateSuccess(orgID string) {
+func init() {
+	SetOrgCmd.Flags().BoolVar(&globalFlag, "global", false, "Set the organization ID globally")
+}
+
+func printOrgUpdateSuccess(orgID string, isGlobal bool) {
 	cprint.PrintHeader("--- Organization Update ---")
-	cprint.Success("Successfully updated organization ID")
+	if isGlobal {
+		cprint.Success("Successfully updated global organization ID")
+	} else {
+		cprint.Success("Successfully updated organization ID")
+	}
 	cprint.PrintDetail("New Organization ID", orgID)
 	fmt.Println()
-	cprint.GreenPrint("Hyphen CLI is now set to use the new organization.")
+	if isGlobal {
+		cprint.GreenPrint("Hyphen CLI is now set to use the new organization globally.")
+	} else {
+		cprint.GreenPrint("Hyphen CLI is now set to use the new organization.")
+	}
 }

--- a/cmd/setproject/setproject.go
+++ b/cmd/setproject/setproject.go
@@ -8,6 +8,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	globalFlag bool
+)
+
 var SetProjectCmd = &cobra.Command{
 	Use:   "set-project <id>",
 	Short: "Set the project ID",
@@ -15,19 +19,38 @@ var SetProjectCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		projectID := args[0]
-		err := manifest.UpsertProjectID(projectID)
+		var err error
+
+		if globalFlag {
+			err = manifest.UpsertGlobalProjectId(projectID)
+		} else {
+			err = manifest.UpsertProjectID(projectID)
+		}
+
 		if err != nil {
 			return fmt.Errorf("failed to update project ID: %w", err)
 		}
-		printProjectUpdateSuccess(projectID)
+		printProjectUpdateSuccess(projectID, globalFlag)
 		return nil
 	},
 }
 
-func printProjectUpdateSuccess(projectID string) {
+func init() {
+	SetProjectCmd.Flags().BoolVar(&globalFlag, "global", false, "Set the project ID globally")
+}
+
+func printProjectUpdateSuccess(projectID string, isGlobal bool) {
 	cprint.PrintHeader("--- Project Update ---")
-	cprint.Success("Successfully updated project ID")
+	if isGlobal {
+		cprint.Success("Successfully updated global project ID")
+	} else {
+		cprint.Success("Successfully updated project ID")
+	}
 	cprint.PrintDetail("New Project ID", projectID)
 	fmt.Println()
-	cprint.GreenPrint("Hyphen CLI is now set to use the new project.")
+	if isGlobal {
+		cprint.GreenPrint("Hyphen CLI is now set to use the new project globally.")
+	} else {
+		cprint.GreenPrint("Hyphen CLI is now set to use the new project.")
+	}
 }

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -283,6 +283,46 @@ func UpsertOrganizationID(organizationID string) error {
 	return nil
 }
 
+func UpsertGlobalOrganizationId(organizationID string) error {
+	globalDir := GetGlobalDirectory()
+	globalConfigFile := filepath.Join(globalDir, ManifestConfigFile)
+
+	var mconfig ManifestConfig
+
+	// Try to read existing global config
+	existingConfig, err := readAndUnmarshalConfigJSON[ManifestConfig](globalConfigFile)
+	if err != nil && !os.IsNotExist(err) {
+		return errors.Wrap(err, "Error reading global config file")
+	}
+
+	// If config exists, use it; otherwise, create a new one
+	if err == nil {
+		mconfig = existingConfig
+	}
+
+	// Update or set the OrganizationId
+	mconfig.OrganizationId = organizationID
+
+	// Ensure the global directory exists
+	if err := FS.MkdirAll(globalDir, 0755); err != nil {
+		return errors.Wrap(err, "Failed to create global directory")
+	}
+
+	// Marshal the updated config to JSON
+	jsonData, err := json.MarshalIndent(mconfig, "", "  ")
+	if err != nil {
+		return errors.Wrap(err, "Error encoding JSON")
+	}
+
+	// Write the updated config to the global file
+	err = FS.WriteFile(globalConfigFile, jsonData, 0644)
+	if err != nil {
+		return errors.Wrapf(err, "Error writing file: %s", globalConfigFile)
+	}
+
+	return nil
+}
+
 func UpsertProjectID(projectID string) error {
 	var mconfig ManifestConfig
 	var hasConfig bool
@@ -337,6 +377,46 @@ func UpsertProjectID(projectID string) error {
 	err = FS.WriteFile(configFile, jsonData, 0644)
 	if err != nil {
 		return errors.Wrapf(err, "Error writing file: %s", configFile)
+	}
+
+	return nil
+}
+
+func UpsertGlobalProjectId(projectID string) error {
+	globalDir := GetGlobalDirectory()
+	globalConfigFile := filepath.Join(globalDir, ManifestConfigFile)
+
+	var mconfig ManifestConfig
+
+	// Try to read existing global config
+	existingConfig, err := readAndUnmarshalConfigJSON[ManifestConfig](globalConfigFile)
+	if err != nil && !os.IsNotExist(err) {
+		return errors.Wrap(err, "Error reading global config file")
+	}
+
+	// If config exists, use it; otherwise, create a new one
+	if err == nil {
+		mconfig = existingConfig
+	}
+
+	// Update or set the ProjectId
+	mconfig.ProjectId = &projectID
+
+	// Ensure the global directory exists
+	if err := FS.MkdirAll(globalDir, 0755); err != nil {
+		return errors.Wrap(err, "Failed to create global directory")
+	}
+
+	// Marshal the updated config to JSON
+	jsonData, err := json.MarshalIndent(mconfig, "", "  ")
+	if err != nil {
+		return errors.Wrap(err, "Error encoding JSON")
+	}
+
+	// Write the updated config to the global file
+	err = FS.WriteFile(globalConfigFile, jsonData, 0644)
+	if err != nil {
+		return errors.Wrapf(err, "Error writing file: %s", globalConfigFile)
 	}
 
 	return nil


### PR DESCRIPTION
This commit introduced a global flag for 'set-org' and 'set-project' commands, allowing users to set the organization and project ID globally. In addition to the changes in the command files, corresponding new functions were added to the manifest go file to handle the global setting of IDs. Now when updating the organization or project, an additional status message indicates whether the operation was set to global.