### PR TITLE
feat: update "push" and "pull" commands in cmd/env

### DIFF
--- a/cmd/env/pull/pull.go
+++ b/cmd/env/pull/pull.go
@@ -31,12 +31,7 @@ Examples:
 
 After pulling, all environment variables will be locally available and ready for use.
 `,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 1 {
-			return fmt.Errorf("accepts at most 1 arg(s), received %d", len(args))
-		}
-		return nil
-	},
+	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		service := newService(env.NewService())
 

--- a/cmd/env/push/push.go
+++ b/cmd/env/push/push.go
@@ -30,12 +30,7 @@ Examples:
 
 After pushing, all environment variables will be securely stored in Hyphen and available for use across your project.
 `,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 1 {
-			return fmt.Errorf("accepts at most 1 arg(s), received %d", len(args))
-		}
-		return nil
-	},
+	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		service := newService(env.NewService())
 


### PR DESCRIPTION
Enhanced the "push" and "pull" commands in cmd/env/push/push.go and cmd/env/pull/pull.go respectively to accept an environment as an optional argument instead of using the "-e" flag. Also, added an error message if more than one argument is provided. The commands will now have the format "hyphen pull [environment]" and "hyphen push [environment]".