### PR TITLE
feat: add 'Args: cobra.NoArgs' to various cmd Go files

### DIFF
--- a/cmd/app/list/list.go
+++ b/cmd/app/list/list.go
@@ -42,6 +42,7 @@ If no applications are found, you'll be informed accordingly.
 
 Use 'hyphen app list --help' for more information about available flags.
 `,
+	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		orgId, err := flags.GetOrganizationID()
 		if err != nil {

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -15,6 +15,7 @@ import (
 var AuthCmd = &cobra.Command{
 	Use:   "auth",
 	Short: "Authenticate with Hyphen",
+	Args:  cobra.NoArgs,
 	Long:  `Authenticate and set up credentials for the Hyphen CLI.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := login(); err != nil {

--- a/cmd/project/list/list.go
+++ b/cmd/project/list/list.go
@@ -12,6 +12,7 @@ import (
 var ProjectListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all projects",
+	Args:  cobra.NoArgs,
 	Long: `
 The project list command retrieves and displays all projects associated with your Hyphen organization.
 

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -80,6 +80,7 @@ var UpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Update the Hyphen CLI",
 	Long:  `This command updates the Hyphen CLI to the specified version or the latest version available for your operating system`,
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		updater := NewDefaultUpdater(version)
 		updater.Run(cmd, args)

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -11,6 +11,7 @@ var Version string
 var VersionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of Hyphen",
+	Args:  cobra.NoArgs,
 	Long:  `All software has versions. This is Hyphen's`,
 	Run: func(cmd *cobra.Command, args []string) {
 		printVersionInfo()


### PR DESCRIPTION
Adds the 'Args: cobra.NoArgs' line to the following cmd Go files: list.go from the app and project modules, auth.go, update.go and version.go. This may prevent unexpected arguments from being considered on command execution.