### PR TITLE
feat: Enhance setorg command and refactor function names

### DIFF
--- a/cmd/setproject/setproject.go
+++ b/cmd/setproject/setproject.go
@@ -22,7 +22,7 @@ var SetProjectCmd = &cobra.Command{
 		var err error
 
 		if globalFlag {
-			err = manifest.UpsertGlobalProjectId(projectID)
+			err = manifest.UpsertGlobalProjectID(projectID)
 		} else {
 			err = manifest.UpsertProjectID(projectID)
 		}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -283,7 +283,7 @@ func UpsertOrganizationID(organizationID string) error {
 	return nil
 }
 
-func UpsertGlobalOrganizationId(organizationID string) error {
+func UpsertGlobalOrganizationID(organizationID string) error {
 	globalDir := GetGlobalDirectory()
 	globalConfigFile := filepath.Join(globalDir, ManifestConfigFile)
 
@@ -382,7 +382,7 @@ func UpsertProjectID(projectID string) error {
 	return nil
 }
 
-func UpsertGlobalProjectId(projectID string) error {
+func UpsertGlobalProjectID(projectID string) error {
 	globalDir := GetGlobalDirectory()
 	globalConfigFile := filepath.Join(globalDir, ManifestConfigFile)
 


### PR DESCRIPTION
- Enhance setorg command to fetch list of projects and set the first project as the default project after setting organization ID.
- Refactor function names from 'UpsertGlobalOrganizationId' and 'UpsertGlobalProjectId' to 'UpsertGlobalOrganizationID' and 'UpsertGlobalProjectID' for consistency with Go naming conventions.