### PR TITLE
feat: improve user confirmation flow in initialize.go

### DIFF
--- a/cmd/initialize/initialize.go
+++ b/cmd/initialize/initialize.go
@@ -96,14 +96,16 @@ func runInit(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	response := prompt.PromptYesNo(cmd, "Config file exists. Do you want to overwrite it?", false)
-	if manifest.ExistsLocal() && !response.Confirmed {
-		if response.IsFlag {
-			cprint.Info("Operation cancelled due to --no flag.")
-		} else {
-			cprint.Info("Operation cancelled.")
+	if manifest.ExistsLocal() {
+		response := prompt.PromptYesNo(cmd, "Config file exists. Do you want to overwrite it?", false)
+		if !response.Confirmed {
+			if response.IsFlag {
+				cprint.Info("Operation cancelled due to --no flag.")
+			} else {
+				cprint.Info("Operation cancelled.")
+			}
+			return
 		}
-		return
 	}
 
 	m, err := manifest.Restore()


### PR DESCRIPTION
This commit enhances the user confirmation process by first checking if a local manifest exists before prompting the user if they want to overwrites it. If the user confirms not to overwrite, based on their response a suitable info message is printed.