### PR TITLE
feat: Update error messages referring to '.hx' file

### DIFF
--- a/cmd/initialize/initialize.go
+++ b/cmd/initialize/initialize.go
@@ -115,7 +115,7 @@ func runInit(cmd *cobra.Command, args []string) {
 	}
 
 	if m.ProjectId == nil {
-		cprint.Error(cmd, fmt.Errorf("no project found in Manifest"))
+		cprint.Error(cmd, fmt.Errorf("No project found in .hx file"))
 		return
 	}
 

--- a/pkg/flags/project.go
+++ b/pkg/flags/project.go
@@ -16,7 +16,7 @@ func GetProjectID() (string, error) {
 	}
 
 	if manifest.ProjectId == nil {
-		return "", errors.New("No Project ID provided and no default found in manifest")
+		return "", errors.New("No Project ID provided and no default found in .hx file")
 	}
 
 	return *manifest.ProjectId, nil


### PR DESCRIPTION
Changed the error messages in 'initialize.go' and 'project.go' files when no project is found, to accurately refer to the '.hx' file instead of the Manifest.