### PR TITLE
feat(install.sh): update install script to include PATH update

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,12 +43,13 @@ detect_shell() {
     esac
 }
 
-# Function to create alias
-create_alias() {
+# Function to create alias and add ~/.local/bin to PATH
+update_shell_config() {
     alias_command="alias hx='hyphen'"
+    path_update='export PATH="$HOME/.local/bin:$PATH"'
     shell=$(detect_shell)
     config_file=""
-    alias_added=false
+    changes_made=false
 
     case "$shell" in
         zsh) config_file="$HOME/.zshrc";;
@@ -60,11 +61,15 @@ create_alias() {
             fi
             ;;
         ksh) config_file="$HOME/.kshrc";;
-        fish) config_file="$HOME/.config/fish/config.fish";;
+        fish) 
+            config_file="$HOME/.config/fish/config.fish"
+            path_update='set -gx PATH "$HOME/.local/bin" $PATH'
+            ;;
         csh|tcsh) config_file="$HOME/.cshrc";;
         *) 
-            printf "\nUnsupported shell. Please add the following alias manually to your shell configuration file:\n"
-            printf "  %s\n\n" "$alias_command"
+            printf "\nUnsupported shell. Please add the following manually to your shell configuration file:\n"
+            printf "  %s\n" "$alias_command"
+            printf "  %s\n\n" "$path_update"
             return
             ;;
     esac
@@ -73,20 +78,20 @@ create_alias() {
         if ! grep -q "$alias_command" "$config_file"; then
             printf "\nAdding alias 'hx' for hyphen to %s\n" "$config_file"
             echo "$alias_command" >> "$config_file"
-            alias_added=true
-        else
-            printf "\nAlias 'hx' already exists in %s\n\n" "$config_file"
-            return
+            changes_made=true
+        fi
+        if ! grep -q "$path_update" "$config_file"; then
+            printf "Adding ~/.local/bin to PATH in %s\n" "$config_file"
+            echo "$path_update" >> "$config_file"
+            changes_made=true
         fi
     fi
 
-    if [ "$alias_added" = true ]; then
-        printf "\nAlias added. Please source the configuration file to apply changes:\n"
+    if [ "$changes_made" = true ]; then
+        printf "\nChanges made to %s. Please run the following command to apply changes:\n" "$config_file"
         printf "  source %s\n\n" "$config_file"
     else
-        printf "\nCould not find a suitable configuration file in your home directory.\n"
-        printf "Please add the following alias manually to your shell configuration file:\n"
-        printf "  %s\n\n" "$alias_command"
+        printf "\nNo changes were necessary in %s\n\n" "$config_file"
     fi
 }
 
@@ -113,25 +118,18 @@ install_cli() {
     
     chmod +x "${temp_dir}/${binary_name}"
 
-    # Determine install location based on OS
-    case "$os" in
-        linux|macos|macos-arm)
-            install_dir="/usr/local/bin"
-            ;;
-        windows)
-            printf "\nWindows installation is not supported by this script.\n\n"
-            exit 1
-            ;;
-    esac
+    # Install to ~/.local/bin
+    install_dir="$HOME/.local/bin"
+    mkdir -p "$install_dir"
 
     printf "\nInstalling %s to %s...\n" "$binary_name" "$install_dir"
-    sudo mv "${temp_dir}/${binary_name}" "${install_dir}/"
+    mv "${temp_dir}/${binary_name}" "${install_dir}/"
 
     printf "\n%s has been successfully installed!\n" "$binary_name"
-    printf "You can now run '%s' from anywhere in your terminal.\n\n" "$binary_name"
+    printf "You can now run '%s' from anywhere in your terminal once you've updated your PATH.\n\n" "$binary_name"
 
-    # Add the alias
-    create_alias
+    # Update shell configuration
+    update_shell_config
 }
 
 # Run the installation with an optional version parameter


### PR DESCRIPTION
Updated the install.sh script. Made modifications to include the addition of ~/.local/bin to the PATH, and moved the installation directory to ~/.local/bin. This includes modifications to the update_shell_config function to include PATH update, and reflect these changes in relevant messages. Also removed OS-specific case conditions for installation directory choice.