### PR TITLE
feat(manifest): refactor manifest usage to use ManifestConfig

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -69,14 +69,14 @@ func login(cmd *cobra.Command) error {
 		idToken = &token.IDToken
 		expiryTime = &token.ExpiryTime
 
-		mc := manifest.ManifestConfig{
+		mc := manifest.Config{
 			HyphenAccessToken:  accessToken,
 			HyphenRefreshToken: refreshToken,
 			HypenIDToken:       idToken,
 			ExpiryTime:         expiryTime,
 		}
 
-		if err := manifest.UpsertGlobalManifestConfig(mc); err != nil {
+		if err := manifest.UpsertGlobalConfig(mc); err != nil {
 			return fmt.Errorf("failed to save credentials: %w", err)
 		}
 
@@ -108,11 +108,11 @@ func login(cmd *cobra.Command) error {
 			apiKey = &flags.SetApiKeyFlag
 		}
 
-		mc := manifest.ManifestConfig{
+		mc := manifest.Config{
 			HyphenAPIKey: apiKey,
 		}
 
-		if err := manifest.UpsertGlobalManifestConfig(mc); err != nil {
+		if err := manifest.UpsertGlobalConfig(mc); err != nil {
 			return fmt.Errorf("failed to save credentials: %w", err)
 		}
 
@@ -139,7 +139,7 @@ func login(cmd *cobra.Command) error {
 
 	defaultProject := projectList[0]
 
-	mc := manifest.ManifestConfig{
+	mc := manifest.Config{
 		ProjectId:          defaultProject.ID,
 		ProjectName:        &defaultProject.Name,
 		ProjectAlternateId: &defaultProject.AlternateID,
@@ -154,7 +154,7 @@ func login(cmd *cobra.Command) error {
 		AppAlternateId:     nil,
 	}
 
-	if err := manifest.GlobalInitializeManifestConfig(mc); err != nil {
+	if err := manifest.GlobalInitializeConfig(mc); err != nil {
 		return err
 	}
 

--- a/cmd/env/rotatekey/rotatekey.go
+++ b/cmd/env/rotatekey/rotatekey.go
@@ -67,7 +67,7 @@ func runRotateKey(cmd *cobra.Command) error {
 		return err
 	}
 
-	manifest.UpsertLocalManifestSecret(newManifestSecret)
+	manifest.UpsertLocalSecret(newManifestSecret)
 
 	push.Silent = true
 	push.RunPush([]string{}, currentManifest.SecretKeyId)
@@ -79,11 +79,11 @@ func runRotateKey(cmd *cobra.Command) error {
 	return nil
 }
 
-func getNewManifestSecret() (manifest.ManifestSecret, error) {
+func getNewManifestSecret() (manifest.Secret, error) {
 	//generate new key
 	newSecretKey, err := secretkey.New()
 	if err != nil {
-		return manifest.ManifestSecret{}, err
+		return manifest.Secret{}, err
 	}
 
 	return manifest.NewSecret(newSecretKey), nil

--- a/cmd/initialize/initialize.go
+++ b/cmd/initialize/initialize.go
@@ -126,7 +126,7 @@ func runInit(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	mcl := manifest.ManifestConfig{
+	mcl := manifest.Config{
 		ProjectId:          m.ProjectId,
 		ProjectAlternateId: m.ProjectAlternateId,
 		ProjectName:        m.ProjectName,

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -111,12 +111,12 @@ func Restore() (Database, error) {
 }
 
 func Save(db Database) error {
-	mc, err := manifest.RestoreManifestConfig()
+	mc, err := manifest.RestoreConfig()
 	if err != nil {
 		return err
 	}
 	mc.Database = db
 
-	return manifest.UpsertGlobalManifestConfig(mc)
+	return manifest.UpsertGlobalConfig(mc)
 
 }

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -74,7 +74,7 @@ func TestInitialize(t *testing.T) {
 	}()
 
 	t.Run("Successful initialization", func(t *testing.T) {
-		mc := ManifestConfig{
+		mc := Config{
 			AppName:        stringPtr("TestApp"),
 			AppId:          stringPtr("app1"),
 			AppAlternateId: stringPtr("test-app"),
@@ -221,12 +221,12 @@ func TestExistsLocal(t *testing.T) {
 }
 
 func TestGetSecretKey(t *testing.T) {
-	ms := ManifestSecret{
+	ms := Secret{
 		SecretKey: "dGVzdC1zZWNyZXQta2V5",
 	}
 	m := Manifest{
-		ManifestConfig: ManifestConfig{},
-		ManifestSecret: ms,
+		Config: Config{},
+		Secret: ms,
 	}
 
 	sk := m.GetSecretKey()

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -345,7 +345,7 @@ func (s *OAuthService) RefreshToken(refreshToken string) (*TokenResponse, error)
 }
 
 func (s *OAuthService) GetValidToken() (string, error) {
-	mc, err := manifest.RestoreManifestConfig()
+	mc, err := manifest.RestoreConfig()
 	if err != nil {
 		return "", err
 	}
@@ -363,7 +363,7 @@ func (s *OAuthService) GetValidToken() (string, error) {
 		mc.HyphenRefreshToken = &tokenResponse.RefreshToken
 		mc.HypenIDToken = &tokenResponse.IDToken
 		mc.ExpiryTime = &tokenResponse.ExpiryTime
-		err = manifest.UpsertGlobalManifestConfig(mc)
+		err = manifest.UpsertGlobalConfig(mc)
 		if err != nil {
 			return "", errors.Wrap(err, "Failed to save refreshed credentials")
 		}

--- a/pkg/httputil/client.go
+++ b/pkg/httputil/client.go
@@ -28,7 +28,7 @@ func NewHyphenHTTPClient() *HyphenClient {
 }
 
 func (hc *HyphenClient) Do(req *http.Request) (*http.Response, error) {
-	manifestConfig, err := manifest.RestoreManifestConfig()
+	manifestConfig, err := manifest.RestoreConfig()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to load .hx")
 	}


### PR DESCRIPTION
Refactored the usage of Manifest to use ManifestConfig. Changed the method Restore to RestoreManifestConfig in internal/oauth/oauth.go, internal/database/database.go and cmd/auth/auth.go files. Updated the reference in internal/manifest/manifest.go and pkg/httputil/client.go to use updated methods and variables.