### PR TITLE
feat(pull.go): change error handling for saveDecryptedEnvIntoFile fun…

### DIFF
--- a/cmd/env/pull/pull.go
+++ b/cmd/env/pull/pull.go
@@ -248,6 +248,9 @@ func (s *service) getAllEnvsAndDecryptIntoFiles(orgId, appId string, secretkey *
 }
 
 func printPullSummary(pulledEnvs []string) {
+	if len(pulledEnvs) == 0 {
+		return
+	}
 	cprint.Print("Pulled environments:")
 	for _, env := range pulledEnvs {
 		if env == "default" {

--- a/cmd/env/pull/pull.go
+++ b/cmd/env/pull/pull.go
@@ -249,6 +249,7 @@ func (s *service) getAllEnvsAndDecryptIntoFiles(orgId, appId string, secretkey *
 
 func printPullSummary(pulledEnvs []string) {
 	if len(pulledEnvs) == 0 {
+		cprint.Print("No environments pulled")
 		return
 	}
 	cprint.Print("Pulled environments:")

--- a/cmd/env/pull/pull.go
+++ b/cmd/env/pull/pull.go
@@ -236,9 +236,13 @@ func (s *service) getAllEnvsAndDecryptIntoFiles(orgId, appId string, secretkey *
 			envName = e.ProjectEnv.AlternateID
 		}
 		if err := s.saveDecryptedEnvIntoFile(orgId, envName, appId, secretkey, m, force); err != nil {
-			return pulledEnvs, err
+			if !Silent {
+				cprint.Warning(fmt.Sprintf("Failed to pull environment %s: %s", envName, err))
+			}
+			continue
 		}
 		pulledEnvs = append(pulledEnvs, envName)
+
 	}
 	return pulledEnvs, nil
 }


### PR DESCRIPTION
…ction

Altered the error handling within saveDecryptedEnvIntoFile function to present the user with a warning message and continue with the process, rather than returning the error and halting execution. This change affects the getAllEnvsAndDecryptIntoFiles method within the cmd/env/pull/pull.go file.