### PR TITLE
refactor:cprint flags circular dependency

### DIFF
--- a/cmd/app/create/create.go
+++ b/cmd/app/create/create.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	appIDFlag string
+	printer   *cprint.CPrinter
 )
 
 var CreateCmd = &cobra.Command{
@@ -45,24 +46,25 @@ ID, and associated organization.
 
 func init() {
 	CreateCmd.Flags().StringVarP(&appIDFlag, "id", "i", "", "App ID (optional)")
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }
 
 func runCreate(cmd *cobra.Command, args []string) {
 	appService := app.NewService()
 	orgID, err := flags.GetOrganizationID()
 	if err != nil {
-		cprint.Error(cmd, err)
+		printer.Error(cmd, err)
 		return
 	}
 	projID, err := flags.GetProjectID()
 	if err != nil {
-		cprint.Error(cmd, err)
+		printer.Error(cmd, err)
 		return
 	}
 
 	appName := args[0]
 	if appName == "" {
-		cprint.Error(cmd, fmt.Errorf("app name is required"))
+		printer.Error(cmd, fmt.Errorf("app name is required"))
 		return
 	}
 
@@ -73,7 +75,7 @@ func runCreate(cmd *cobra.Command, args []string) {
 
 	newApp, err := appService.CreateApp(orgID, projID, appAlternateId, appName)
 	if err != nil {
-		cprint.Error(cmd, err)
+		printer.Error(cmd, err)
 		return
 	}
 
@@ -93,7 +95,7 @@ func getAppID(cmd *cobra.Command, appName string) string {
 		response := prompt.PromptYesNo(cmd, fmt.Sprintf("Invalid app ID. Do you want to use the suggested ID [%s]?", suggestedID), true)
 
 		if response.IsFlag && !response.Confirmed {
-			cprint.Info("Operation cancelled due to --no flag.")
+			printer.Info("Operation cancelled due to --no flag.")
 			return ""
 		}
 
@@ -103,7 +105,7 @@ func getAppID(cmd *cobra.Command, appName string) string {
 				var err error
 				customID, err = prompt.PromptString(cmd, "Enter a custom app ID:")
 				if err != nil {
-					cprint.Error(cmd, err)
+					printer.Error(cmd, err)
 					return ""
 				}
 
@@ -111,7 +113,7 @@ func getAppID(cmd *cobra.Command, appName string) string {
 				if err == nil {
 					return customID
 				}
-				cprint.Warning("Invalid app ID. Please try again.")
+				printer.Warning("Invalid app ID. Please try again.")
 			}
 		}
 		appAlternateId = suggestedID
@@ -124,10 +126,10 @@ func generateDefaultAppId(appName string) string {
 }
 
 func printCreationSummary(appName, appAlternateId, appID, orgID string) {
-	cprint.Success("App successfully created")
-	cprint.Print("") // Print an empty line for spacing
-	cprint.PrintDetail("App Name", appName)
-	cprint.PrintDetail("App AlternateId", appAlternateId)
-	cprint.PrintDetail("App ID", appID)
-	cprint.PrintDetail("Organization ID", orgID)
+	printer.Success("App successfully created")
+	printer.Print("") // Print an empty line for spacing
+	printer.PrintDetail("App Name", appName)
+	printer.PrintDetail("App AlternateId", appAlternateId)
+	printer.PrintDetail("App ID", appID)
+	printer.PrintDetail("Organization ID", orgID)
 }

--- a/cmd/app/create/create.go
+++ b/cmd/app/create/create.go
@@ -46,10 +46,10 @@ ID, and associated organization.
 
 func init() {
 	CreateCmd.Flags().StringVarP(&appIDFlag, "id", "i", "", "App ID (optional)")
-	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }
 
 func runCreate(cmd *cobra.Command, args []string) {
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
 	appService := app.NewService()
 	orgID, err := flags.GetOrganizationID()
 	if err != nil {

--- a/cmd/app/get/get.go
+++ b/cmd/app/get/get.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var printer *cprint.CPrinter
+
 var GetCmd = &cobra.Command{
 	Use:   "get <app name or id>",
 	Short: "Get an app",
@@ -38,25 +40,26 @@ After execution, you'll see a summary of the application's details.
 }
 
 func init() {
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }
 
 func runGet(cmd *cobra.Command, args []string) {
 	appService := app.NewService()
 	orgID, err := flags.GetOrganizationID()
 	if err != nil {
-		cprint.Error(cmd, err)
+		printer.Error(cmd, err)
 		return
 	}
 
 	appIdentifier := args[0]
 	if appIdentifier == "" {
-		cprint.Error(cmd, fmt.Errorf("app name or id is required"))
+		printer.Error(cmd, fmt.Errorf("app name or id is required"))
 		return
 	}
 
 	retrievedApp, err := appService.GetApp(orgID, appIdentifier)
 	if err != nil {
-		cprint.Error(cmd, err)
+		printer.Error(cmd, err)
 		return
 	}
 
@@ -64,11 +67,11 @@ func runGet(cmd *cobra.Command, args []string) {
 }
 
 func printAppDetails(app app.App) {
-	cprint.PrintDetail("Project ID", app.Project.ID)
-	cprint.PrintDetail("Project Name", app.Project.Name)
-	cprint.PrintDetail("App Name", app.Name)
-	cprint.PrintDetail("App AlternateId", app.AlternateId)
-	cprint.PrintDetail("App ID", app.ID)
-	cprint.PrintDetail("Organization ID", app.Organization.ID)
-	cprint.PrintDetail("Organization Name", app.Organization.Name)
+	printer.PrintDetail("Project ID", app.Project.ID)
+	printer.PrintDetail("Project Name", app.Project.Name)
+	printer.PrintDetail("App Name", app.Name)
+	printer.PrintDetail("App AlternateId", app.AlternateId)
+	printer.PrintDetail("App ID", app.ID)
+	printer.PrintDetail("Organization ID", app.Organization.ID)
+	printer.PrintDetail("Organization Name", app.Organization.Name)
 }

--- a/cmd/app/get/get.go
+++ b/cmd/app/get/get.go
@@ -39,11 +39,9 @@ After execution, you'll see a summary of the application's details.
 	Run:  runGet,
 }
 
-func init() {
-	printer = cprint.NewCPrinter(flags.VerboseFlag)
-}
-
 func runGet(cmd *cobra.Command, args []string) {
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
+
 	appService := app.NewService()
 	orgID, err := flags.GetOrganizationID()
 	if err != nil {

--- a/cmd/app/list/list.go
+++ b/cmd/app/list/list.go
@@ -45,6 +45,7 @@ Use 'hyphen app list --help' for more information about available flags.
 `,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
+		printer = cprint.NewCPrinter(flags.VerboseFlag)
 		orgId, err := flags.GetOrganizationID()
 		if err != nil {
 			printer.Error(cmd, err)
@@ -136,5 +137,4 @@ func init() {
 	ListCmd.Flags().IntVar(&pageSize, "page-size", 10, "Number of results per page")
 	ListCmd.Flags().IntVar(&page, "page", 1, "Page number")
 	ListCmd.Flags().BoolVar(&showTable, "table", false, "Display results in a table format")
-	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }

--- a/cmd/app/list/list.go
+++ b/cmd/app/list/list.go
@@ -16,6 +16,7 @@ var (
 	pageSize  int
 	page      int
 	showTable bool
+	printer   *cprint.CPrinter
 )
 
 var ListCmd = &cobra.Command{
@@ -46,24 +47,24 @@ Use 'hyphen app list --help' for more information about available flags.
 	Run: func(cmd *cobra.Command, args []string) {
 		orgId, err := flags.GetOrganizationID()
 		if err != nil {
-			cprint.Error(cmd, err)
+			printer.Error(cmd, err)
 			return
 		}
 		projectId, err := flags.GetProjectID()
 		if err != nil {
-			cprint.Error(cmd, err)
+			printer.Error(cmd, err)
 			return
 		}
 		service := newService(app.NewService())
 
 		apps, err := service.ListApps(orgId, projectId, pageSize, page)
 		if err != nil {
-			cprint.Error(cmd, fmt.Errorf("failed to list apps: %w", err))
+			printer.Error(cmd, fmt.Errorf("failed to list apps: %w", err))
 			return
 		}
 
 		if len(apps) == 0 {
-			cprint.Info("No applications found for the specified organization.")
+			printer.Info("No applications found for the specified organization.")
 			return
 		}
 
@@ -108,11 +109,11 @@ func displayTable(apps []app.App) {
 
 func displayList(apps []app.App) {
 	for _, app := range apps {
-		cprint.PrintDetail("App Name", app.Name)
-		cprint.PrintDetail("App AlternateId", app.AlternateId)
-		cprint.PrintDetail("App ID", app.ID)
-		cprint.PrintDetail("Organization ID", app.Organization.ID)
-		cprint.PrintDetail("Organization Name", app.Organization.Name)
+		printer.PrintDetail("App Name", app.Name)
+		printer.PrintDetail("App AlternateId", app.AlternateId)
+		printer.PrintDetail("App ID", app.ID)
+		printer.PrintDetail("Organization ID", app.Organization.ID)
+		printer.PrintDetail("Organization Name", app.Organization.Name)
 		fmt.Println()
 	}
 }
@@ -135,4 +136,5 @@ func init() {
 	ListCmd.Flags().IntVar(&pageSize, "page-size", 10, "Number of results per page")
 	ListCmd.Flags().IntVar(&page, "page", 1, "Page number")
 	ListCmd.Flags().BoolVar(&showTable, "table", false, "Display results in a table format")
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -14,6 +14,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var printer *cprint.CPrinter
+
 var AuthCmd = &cobra.Command{
 	Use:   "auth",
 	Short: "Authenticate with Hyphen",
@@ -33,7 +35,7 @@ Examples:
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := login(cmd); err != nil {
-			cprint.Error(cmd, err)
+			printer.Error(cmd, err)
 			return
 		}
 	},
@@ -42,6 +44,7 @@ Examples:
 func init() {
 	AuthCmd.PersistentFlags().StringVar(&flags.SetApiKeyFlag, "set-api-key", "", "Authenticate using API key provided inline")
 	AuthCmd.PersistentFlags().BoolVar(&flags.UseApiKeyFlag, "use-api-key", false, "Authenticate using an API key provided via prompt or HYPHEN_API_KEY env variable")
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }
 
 func login(cmd *cobra.Command) error {
@@ -61,7 +64,7 @@ func login(cmd *cobra.Command) error {
 		}
 
 		if flags.VerboseFlag {
-			cprint.Success("OAuth server started successfully")
+			printer.Success("OAuth server started successfully")
 		}
 
 		accessToken = &token.AccessToken
@@ -81,7 +84,7 @@ func login(cmd *cobra.Command) error {
 		}
 
 		if flags.VerboseFlag {
-			cprint.Success("Credentials saved successfully")
+			printer.Success("Credentials saved successfully")
 		}
 	} else { // API key login flow
 		if flags.UseApiKeyFlag {
@@ -117,7 +120,7 @@ func login(cmd *cobra.Command) error {
 		}
 
 		if flags.VerboseFlag {
-			cprint.Success("Credentials saved successfully")
+			printer.Success("Credentials saved successfully")
 		}
 	}
 
@@ -164,13 +167,13 @@ func login(cmd *cobra.Command) error {
 
 func printAuthenticationSummary(user *user.ExecutionContext, organizationID string, projectID string) {
 	if flags.VerboseFlag {
-		cprint.PrintHeader("Authentication Summary")
-		cprint.Success("Login successful!")
-		cprint.Print("") // Add an empty line for better spacing
-		cprint.PrintDetail("User", user.User.Name)
-		cprint.PrintDetail("Organization ID", organizationID)
-		cprint.PrintDetail("Default Project ID", projectID)
-		cprint.Print("") // Add an empty line for better spacing
+		printer.PrintHeader("Authentication Summary")
+		printer.Success("Login successful!")
+		printer.Print("") // Add an empty line for better spacing
+		printer.PrintDetail("User", user.User.Name)
+		printer.PrintDetail("Organization ID", organizationID)
+		printer.PrintDetail("Default Project ID", projectID)
+		printer.Print("") // Add an empty line for better spacing
 	}
-	cprint.GreenPrint("You are now authenticated and ready to use Hyphen CLI.")
+	printer.GreenPrint("You are now authenticated and ready to use Hyphen CLI.")
 }

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -34,6 +34,7 @@ Examples:
 	hyphen auth --set-api-key YOURKEY1234
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
+		printer = cprint.NewCPrinter(flags.VerboseFlag)
 		if err := login(cmd); err != nil {
 			printer.Error(cmd, err)
 			return
@@ -44,7 +45,6 @@ Examples:
 func init() {
 	AuthCmd.PersistentFlags().StringVar(&flags.SetApiKeyFlag, "set-api-key", "", "Authenticate using API key provided inline")
 	AuthCmd.PersistentFlags().BoolVar(&flags.UseApiKeyFlag, "use-api-key", false, "Authenticate using an API key provided via prompt or HYPHEN_API_KEY env variable")
-	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }
 
 func login(cmd *cobra.Command) error {

--- a/cmd/env/list/list.go
+++ b/cmd/env/list/list.go
@@ -50,6 +50,7 @@ Examples:
     `,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
+		printer = cprint.NewCPrinter(flags.VerboseFlag)
 		if err := RunList(args); err != nil {
 			printer.Error(cmd, err)
 		}
@@ -169,5 +170,4 @@ func init() {
 	ListCmd.Flags().IntVar(&pageSize, "page-size", 10, "Number of results per page")
 	ListCmd.Flags().IntVar(&page, "page", 1, "Page number")
 	ListCmd.Flags().BoolVar(&showTable, "table", false, "Display results in a table format")
-	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }

--- a/cmd/env/list/list.go
+++ b/cmd/env/list/list.go
@@ -16,6 +16,7 @@ var (
 	pageSize  int
 	page      int
 	showTable bool
+	printer   *cprint.CPrinter
 )
 
 var ListCmd = &cobra.Command{
@@ -50,7 +51,7 @@ Examples:
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := RunList(args); err != nil {
-			cprint.Error(cmd, err)
+			printer.Error(cmd, err)
 		}
 	},
 }
@@ -75,7 +76,7 @@ func RunList(args []string) error {
 	}
 
 	if len(envs) == 0 {
-		cprint.Info("No environments found.")
+		printer.Info("No environments found.")
 		return nil
 	}
 
@@ -143,22 +144,22 @@ func displayList(envs []env.Env) {
 		if e.ProjectEnv != nil {
 			id = e.ProjectEnv.AlternateID
 		}
-		cprint.PrintHeader(fmt.Sprintf("ID: %s", id))
+		printer.PrintHeader(fmt.Sprintf("ID: %s", id))
 
 		version := "-"
 		if e.Version != nil {
 			version = fmt.Sprintf("%d", *e.Version)
 		}
-		cprint.PrintDetail("Version", version)
+		printer.PrintDetail("Version", version)
 
-		cprint.PrintDetail("Secrets Count", fmt.Sprintf("%d", e.CountVariables))
-		cprint.PrintDetail("Size", e.Size)
+		printer.PrintDetail("Secrets Count", fmt.Sprintf("%d", e.CountVariables))
+		printer.PrintDetail("Size", e.Size)
 
 		publishedTime := "-"
 		if e.Published != nil {
 			publishedTime = e.Published.Format("01/02/2006 3:04:05 PM")
 		}
-		cprint.PrintDetail("Published", publishedTime)
+		printer.PrintDetail("Published", publishedTime)
 
 		fmt.Println()
 	}
@@ -168,4 +169,5 @@ func init() {
 	ListCmd.Flags().IntVar(&pageSize, "page-size", 10, "Number of results per page")
 	ListCmd.Flags().IntVar(&page, "page", 1, "Page number")
 	ListCmd.Flags().BoolVar(&showTable, "table", false, "Display results in a table format")
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }

--- a/cmd/env/listversions/listversions.go
+++ b/cmd/env/listversions/listversions.go
@@ -52,6 +52,7 @@ Examples:
     `,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		printer = cprint.NewCPrinter(flags.VerboseFlag)
 		if err := RunListVersions(args[0]); err != nil {
 			printer.Error(cmd, err)
 		}
@@ -166,5 +167,4 @@ func init() {
 	ListVersionsCmd.Flags().IntVar(&pageSize, "page-size", 10, "Number of results per page")
 	ListVersionsCmd.Flags().IntVar(&page, "page", 1, "Page number")
 	ListVersionsCmd.Flags().BoolVar(&showTable, "table", false, "Display results in a table format")
-	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }

--- a/cmd/env/listversions/listversions.go
+++ b/cmd/env/listversions/listversions.go
@@ -16,6 +16,7 @@ var (
 	pageSize  int
 	page      int
 	showTable bool
+	printer   *cprint.CPrinter
 )
 
 var ListVersionsCmd = &cobra.Command{
@@ -52,7 +53,7 @@ Examples:
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := RunListVersions(args[0]); err != nil {
-			cprint.Error(cmd, err)
+			printer.Error(cmd, err)
 		}
 	},
 }
@@ -77,7 +78,7 @@ func RunListVersions(environmentId string) error {
 	}
 
 	if len(envs) == 0 {
-		cprint.Info("No versions found for the specified environment.")
+		printer.Info("No versions found for the specified environment.")
 		return nil
 	}
 
@@ -140,22 +141,22 @@ func displayList(envs []env.Env) {
 		if e.ProjectEnv != nil {
 			id = e.ProjectEnv.AlternateID
 		}
-		cprint.PrintHeader(fmt.Sprintf("ID: %s", id))
+		printer.PrintHeader(fmt.Sprintf("ID: %s", id))
 
 		version := "-"
 		if e.Version != nil {
 			version = fmt.Sprintf("%d", *e.Version)
 		}
-		cprint.PrintDetail("Version", version)
+		printer.PrintDetail("Version", version)
 
-		cprint.PrintDetail("Secrets Count", fmt.Sprintf("%d", e.CountVariables))
-		cprint.PrintDetail("Size", e.Size)
+		printer.PrintDetail("Secrets Count", fmt.Sprintf("%d", e.CountVariables))
+		printer.PrintDetail("Size", e.Size)
 
 		publishedTime := "-"
 		if e.Published != nil {
 			publishedTime = e.Published.Format("01/02/2006 3:04:05 PM")
 		}
-		cprint.PrintDetail("Published", publishedTime)
+		printer.PrintDetail("Published", publishedTime)
 
 		fmt.Println()
 	}
@@ -165,4 +166,5 @@ func init() {
 	ListVersionsCmd.Flags().IntVar(&pageSize, "page-size", 10, "Number of results per page")
 	ListVersionsCmd.Flags().IntVar(&page, "page", 1, "Page number")
 	ListVersionsCmd.Flags().BoolVar(&showTable, "table", false, "Display results in a table format")
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }

--- a/cmd/env/pull/pull.go
+++ b/cmd/env/pull/pull.go
@@ -19,6 +19,7 @@ var (
 	forceFlag  bool
 	version    int
 	versionPtr *int = nil
+	printer    *cprint.CPrinter
 )
 
 var PullCmd = &cobra.Command{
@@ -45,7 +46,7 @@ After pulling, all environment variables will be locally available and ready for
 			versionPtr = &version
 		}
 		if err := RunPull(args, forceFlag); err != nil {
-			cprint.Error(cmd, err)
+			printer.Error(cmd, err)
 		}
 	},
 }
@@ -121,6 +122,7 @@ func RunPull(args []string, forceFlag bool) error {
 func init() {
 	PullCmd.Flags().BoolVar(&forceFlag, "force", false, "Force overwrite of locally modified environment files")
 	PullCmd.Flags().IntVar(&version, "version", 0, "Specify a version to pull")
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }
 
 type service struct {
@@ -192,7 +194,7 @@ func (s *service) saveDecryptedEnvIntoFile(orgId, envName, appId string, secretK
 
 		// Handle NotFound error
 		if !Silent {
-			cprint.Warning(fmt.Sprintf("No version found for environment %s. Pulling the latest version.", envName))
+			printer.Warning(fmt.Sprintf("No version found for environment %s. Pulling the latest version.", envName))
 		}
 
 		// Retry without version
@@ -237,7 +239,7 @@ func (s *service) getAllEnvsAndDecryptIntoFiles(orgId, appId string, secretkey *
 		}
 		if err := s.saveDecryptedEnvIntoFile(orgId, envName, appId, secretkey, m, force); err != nil {
 			if !Silent {
-				cprint.Warning(fmt.Sprintf("Failed to pull environment %s: %s", envName, err))
+				printer.Warning(fmt.Sprintf("Failed to pull environment %s: %s", envName, err))
 			}
 			continue
 		}
@@ -249,15 +251,15 @@ func (s *service) getAllEnvsAndDecryptIntoFiles(orgId, appId string, secretkey *
 
 func printPullSummary(pulledEnvs []string) {
 	if len(pulledEnvs) == 0 {
-		cprint.Print("No environments pulled")
+		printer.Print("No environments pulled")
 		return
 	}
-	cprint.Print("Pulled environments:")
+	printer.Print("Pulled environments:")
 	for _, env := range pulledEnvs {
 		if env == "default" {
-			cprint.Print("  - default -> .env")
+			printer.Print("  - default -> .env")
 		} else {
-			cprint.Print(fmt.Sprintf("  - %s -> .env.%s", env, env))
+			printer.Print(fmt.Sprintf("  - %s -> .env.%s", env, env))
 		}
 	}
 }

--- a/cmd/env/pull/pull.go
+++ b/cmd/env/pull/pull.go
@@ -42,6 +42,7 @@ After pulling, all environment variables will be locally available and ready for
 `,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		printer = cprint.NewCPrinter(flags.VerboseFlag)
 		if version != 0 {
 			versionPtr = &version
 		}
@@ -122,7 +123,6 @@ func RunPull(args []string, forceFlag bool) error {
 func init() {
 	PullCmd.Flags().BoolVar(&forceFlag, "force", false, "Force overwrite of locally modified environment files")
 	PullCmd.Flags().IntVar(&version, "version", 0, "Specify a version to pull")
-	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }
 
 type service struct {

--- a/cmd/env/push/push.go
+++ b/cmd/env/push/push.go
@@ -37,6 +37,7 @@ After pushing, all environment variables will be securely stored in Hyphen and a
 `,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		printer = cprint.NewCPrinter(flags.VerboseFlag)
 		m, err := manifest.Restore()
 		if err != nil {
 			printer.Error(cmd, err)
@@ -231,8 +232,4 @@ func printPushSummary(envsToPush []string, envsPushed []string) {
 			printer.Success(fmt.Sprintf("Successfully pushed environment '%s'", envsToPush[0]))
 		}
 	}
-}
-
-func init() {
-	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }

--- a/cmd/env/push/push.go
+++ b/cmd/env/push/push.go
@@ -14,6 +14,7 @@ import (
 )
 
 var Silent bool = false
+var printer *cprint.CPrinter
 
 var PushCmd = &cobra.Command{
 	Use:   "push [environment]",
@@ -38,10 +39,10 @@ After pushing, all environment variables will be securely stored in Hyphen and a
 	Run: func(cmd *cobra.Command, args []string) {
 		m, err := manifest.Restore()
 		if err != nil {
-			cprint.Error(cmd, err)
+			printer.Error(cmd, err)
 		}
 		if err := RunPush(args, m.SecretKeyId); err != nil {
-			cprint.Error(cmd, err)
+			printer.Error(cmd, err)
 		}
 	},
 }
@@ -91,12 +92,12 @@ func RunPush(args []string, secretKeyId int64) error {
 	for _, envName := range envsToPush {
 		e, err := env.GetLocalEncryptedEnv(envName, manifest)
 		if err != nil {
-			cprint.Error(nil, err)
+			printer.Error(nil, err)
 			continue
 		}
 		err, skippable := service.putEnv(orgId, envName, appId, e, manifest.GetSecretKey(), manifest, secretKeyId)
 		if err != nil {
-			cprint.Error(nil, err)
+			printer.Error(nil, err)
 			continue
 		} else if !skippable {
 			envsPushed = append(envsPushed, envName)
@@ -135,7 +136,7 @@ func (s *service) putEnv(orgID, envName, appID string, e env.Env, secretKey secr
 		}
 		if skippable && m.SecretKeyId == secretKeyId {
 			if !Silent {
-				cprint.Info(fmt.Sprintf("Local %s environment is already up to date - skipping", envName))
+				printer.Info(fmt.Sprintf("Local %s environment is already up to date - skipping", envName))
 			}
 			return nil, true
 		}
@@ -219,15 +220,19 @@ func (s *service) getLocalEnvsNamesFromFiles() ([]string, error) {
 
 func printPushSummary(envsToPush []string, envsPushed []string) {
 	if len(envsToPush) > 1 {
-		cprint.PrintDetail("Local environments", strings.Join(envsToPush, ", "))
+		printer.PrintDetail("Local environments", strings.Join(envsToPush, ", "))
 		if len(envsPushed) > 0 {
-			cprint.PrintDetail("Environments pushed", strings.Join(envsPushed, ", "))
+			printer.PrintDetail("Environments pushed", strings.Join(envsPushed, ", "))
 		} else {
-			cprint.PrintDetail("Environments pushed", "None")
+			printer.PrintDetail("Environments pushed", "None")
 		}
 	} else {
 		if len(envsToPush) == 1 && len(envsPushed) == 1 {
-			cprint.Success(fmt.Sprintf("Successfully pushed environment '%s'", envsToPush[0]))
+			printer.Success(fmt.Sprintf("Successfully pushed environment '%s'", envsToPush[0]))
 		}
 	}
+}
+
+func init() {
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }

--- a/cmd/env/rotatekey/rotatekey.go
+++ b/cmd/env/rotatekey/rotatekey.go
@@ -24,6 +24,7 @@ var RotateCmd = &cobra.Command{
 	Long:  `This command rotates the encryption key and updates all environments with the new key.`,
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
+		printer = cprint.NewCPrinter(flags.VerboseFlag)
 		if err := runRotateKey(cmd); err != nil {
 			printer.Error(cmd, err)
 		}
@@ -32,7 +33,6 @@ var RotateCmd = &cobra.Command{
 
 func init() {
 	RotateCmd.Flags().BoolVar(&forceFlag, "force", false, "Force overwrite of locally modified environment files")
-	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }
 
 func runRotateKey(cmd *cobra.Command) error {

--- a/cmd/env/rotatekey/rotatekey.go
+++ b/cmd/env/rotatekey/rotatekey.go
@@ -8,12 +8,14 @@ import (
 	"github.com/Hyphen/cli/internal/manifest"
 	"github.com/Hyphen/cli/internal/secretkey"
 	"github.com/Hyphen/cli/pkg/cprint"
+	"github.com/Hyphen/cli/pkg/flags"
 	"github.com/Hyphen/cli/pkg/prompt"
 	"github.com/spf13/cobra"
 )
 
 var (
 	forceFlag bool
+	printer   *cprint.CPrinter
 )
 
 var RotateCmd = &cobra.Command{
@@ -23,33 +25,34 @@ var RotateCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := runRotateKey(cmd); err != nil {
-			cprint.Error(cmd, err)
+			printer.Error(cmd, err)
 		}
 	},
 }
 
 func init() {
 	RotateCmd.Flags().BoolVar(&forceFlag, "force", false, "Force overwrite of locally modified environment files")
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }
 
 func runRotateKey(cmd *cobra.Command) error {
 	// Display warning and prompt for confirmation
-	cprint.Warning("You are about to rotate the encryption key. This action is irreversible and will affect all environments.")
-	cprint.Info("Make sure you have a backup of your current configuration before proceeding.")
-	cprint.Info("This action will:")
-	cprint.Info("  1. Generate a new encryption key")
-	cprint.Info("  2. Re-encrypt all environment variables with the new key")
-	cprint.Info("  3. Update the local configuration with the new key")
-	cprint.Info("\nAre you absolutely sure you want to proceed?")
+	printer.Warning("You are about to rotate the encryption key. This action is irreversible and will affect all environments.")
+	printer.Info("Make sure you have a backup of your current configuration before proceeding.")
+	printer.Info("This action will:")
+	printer.Info("  1. Generate a new encryption key")
+	printer.Info("  2. Re-encrypt all environment variables with the new key")
+	printer.Info("  3. Update the local configuration with the new key")
+	printer.Info("\nAre you absolutely sure you want to proceed?")
 
 	response := prompt.PromptYesNo(cmd, "Rotate encryption key?", false)
 	if !response.Confirmed {
-		cprint.Info("Key rotation cancelled.")
+		printer.Info("Key rotation cancelled.")
 		return nil
 	}
 
 	// Proceed with key rotation
-	cprint.Info("Proceeding with key rotation...")
+	printer.Info("Proceeding with key rotation...")
 
 	//Get all the envs
 	pull.Silent = true
@@ -72,9 +75,9 @@ func runRotateKey(cmd *cobra.Command) error {
 	push.Silent = true
 	push.RunPush([]string{}, currentManifest.SecretKeyId)
 
-	cprint.Success("Key rotation completed successfully.")
-	cprint.Info("New encryption key has been generated and all environments have been updated.")
-	cprint.Info("Please ensure all team members pull the latest changes.")
+	printer.Success("Key rotation completed successfully.")
+	printer.Info("New encryption key has been generated and all environments have been updated.")
+	printer.Info("Please ensure all team members pull the latest changes.")
 
 	return nil
 }

--- a/cmd/env/run/run.go
+++ b/cmd/env/run/run.go
@@ -32,6 +32,8 @@ Examples:
   hyphen env run -- go run main.go (uses default environment)
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		printer = cprint.NewCPrinter(flags.VerboseFlag)
+
 		var envName string
 		var childCommand []string
 
@@ -127,8 +129,4 @@ func runCommandWithEnv(command []string, envVars []string) error {
 		printer.Info(fmt.Sprintf("Executing command: %s", strings.Join(command, " ")))
 	}
 	return cmd.Run()
-}
-
-func init() {
-	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }

--- a/cmd/initialize/initialize.go
+++ b/cmd/initialize/initialize.go
@@ -51,11 +51,11 @@ Examples:
 }
 
 func init() {
-	printer = cprint.NewCPrinter(flags.VerboseFlag)
 	InitCmd.Flags().StringVarP(&appIDFlag, "id", "i", "", "App ID (optional)")
 }
 
 func runInit(cmd *cobra.Command, args []string) {
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
 	appService := app.NewService()
 	envService := env.NewService()
 

--- a/cmd/initialize/initialize.go
+++ b/cmd/initialize/initialize.go
@@ -17,6 +17,7 @@ import (
 )
 
 var appIDFlag string
+var printer *cprint.CPrinter
 
 var InitCmd = &cobra.Command{
 	Use:   "init <app name>",
@@ -50,6 +51,7 @@ Examples:
 }
 
 func init() {
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
 	InitCmd.Flags().StringVarP(&appIDFlag, "id", "i", "", "App ID (optional)")
 }
 
@@ -59,7 +61,7 @@ func runInit(cmd *cobra.Command, args []string) {
 
 	orgID, err := flags.GetOrganizationID()
 	if err != nil {
-		cprint.Error(cmd, err)
+		printer.Error(cmd, err)
 		return
 	}
 
@@ -68,7 +70,7 @@ func runInit(cmd *cobra.Command, args []string) {
 		// get the local directory name and prompt if we wish to use this as the app name
 		cwd, err := os.Getwd()
 		if err != nil {
-			cprint.Error(cmd, err)
+			printer.Error(cmd, err)
 			return
 		}
 
@@ -76,14 +78,14 @@ func runInit(cmd *cobra.Command, args []string) {
 		response := prompt.PromptYesNo(cmd, fmt.Sprintf("Use the current directory name '%s' as the app name?", appName), true)
 		if !response.Confirmed {
 			if response.IsFlag {
-				cprint.Info("Operation cancelled due to --no flag.")
+				printer.Info("Operation cancelled due to --no flag.")
 				return
 			} else {
 				// Prompt for a new app name
 				var err error
 				appName, err = prompt.PromptString(cmd, "What would you like the app name to be?")
 				if err != nil {
-					cprint.Error(cmd, err)
+					printer.Error(cmd, err)
 					return
 				}
 			}
@@ -101,9 +103,9 @@ func runInit(cmd *cobra.Command, args []string) {
 		response := prompt.PromptYesNo(cmd, "Config file exists. Do you want to overwrite it?", false)
 		if !response.Confirmed {
 			if response.IsFlag {
-				cprint.Info("Operation cancelled due to --no flag.")
+				printer.Info("Operation cancelled due to --no flag.")
 			} else {
-				cprint.Info("Operation cancelled.")
+				printer.Info("Operation cancelled.")
 			}
 			return
 		}
@@ -111,18 +113,18 @@ func runInit(cmd *cobra.Command, args []string) {
 
 	mc, err := manifest.RestoreConfig()
 	if err != nil {
-		cprint.Error(cmd, err)
+		printer.Error(cmd, err)
 		return
 	}
 
 	if mc.ProjectId == nil {
-		cprint.Error(cmd, fmt.Errorf("No project found in .hx file"))
+		printer.Error(cmd, fmt.Errorf("No project found in .hx file"))
 		return
 	}
 
 	newApp, err := appService.CreateApp(orgID, *mc.ProjectId, appAlternateId, appName)
 	if err != nil {
-		cprint.Error(cmd, err)
+		printer.Error(cmd, err)
 		return
 	}
 
@@ -138,18 +140,18 @@ func runInit(cmd *cobra.Command, args []string) {
 
 	ml, err := manifest.LocalInitialize(mcl) //Loading the local hxkey
 	if err != nil {
-		cprint.Error(cmd, err)
+		printer.Error(cmd, err)
 		return
 	}
 
 	if err := ensureGitignore(manifest.ManifestSecretFile); err != nil {
-		cprint.Error(cmd, fmt.Errorf("error adding .hxkey to .gitignore: %w. Please do this manually if you wish", err))
+		printer.Error(cmd, fmt.Errorf("error adding .hxkey to .gitignore: %w. Please do this manually if you wish", err))
 	}
 
 	// List the environments for the project
 	environments, err := envService.ListEnvironments(orgID, *mc.ProjectId, 100, 1)
 	if err != nil {
-		cprint.Error(cmd, err)
+		printer.Error(cmd, err)
 		return
 	}
 
@@ -159,14 +161,14 @@ func runInit(cmd *cobra.Command, args []string) {
 		envID := e.ID
 		err = createAndPushEmptyEnvFile(cmd, envService, ml, orgID, newApp.ID, envID, envName)
 		if err != nil {
-			cprint.Error(cmd, err)
+			printer.Error(cmd, err)
 			return
 		}
 	}
 
 	err = createAndPushEmptyEnvFile(cmd, envService, ml, orgID, newApp.ID, "default", "default")
 	if err != nil {
-		cprint.Error(cmd, err)
+		printer.Error(cmd, err)
 		return
 	}
 
@@ -235,7 +237,7 @@ func createGitignoredFile(cmd *cobra.Command, fileName string) error {
 	// Create the file
 	file, err := os.Create(fileName)
 	if err != nil {
-		cprint.Error(cmd, fmt.Errorf("error creating %s: %w", fileName, err))
+		printer.Error(cmd, fmt.Errorf("error creating %s: %w", fileName, err))
 		return err
 	}
 	defer file.Close()
@@ -243,12 +245,12 @@ func createGitignoredFile(cmd *cobra.Command, fileName string) error {
 	// Write '# KEY=Value' to the file
 	_, err = file.WriteString("# Example\n# KEY=Value\n")
 	if err != nil {
-		cprint.Error(cmd, fmt.Errorf("error writing to %s: %w", fileName, err))
+		printer.Error(cmd, fmt.Errorf("error writing to %s: %w", fileName, err))
 		return err
 	}
 
 	if err := ensureGitignore(fileName); err != nil {
-		cprint.Error(cmd, fmt.Errorf("error adding %s to .gitignore: %w. Please do this manually if you wish", fileName, err))
+		printer.Error(cmd, fmt.Errorf("error adding %s to .gitignore: %w. Please do this manually if you wish", fileName, err))
 		// don't error here. Keep going.
 	}
 
@@ -269,7 +271,7 @@ func getAppID(cmd *cobra.Command, appName string) string {
 
 		if !response.Confirmed {
 			if response.IsFlag {
-				cprint.Info("Operation cancelled due to --no flag.")
+				printer.Info("Operation cancelled due to --no flag.")
 				return ""
 			} else {
 				// Prompt for a custom app ID
@@ -277,7 +279,7 @@ func getAppID(cmd *cobra.Command, appName string) string {
 					var err error
 					appAlternateId, err = prompt.PromptString(cmd, "Enter a custom app ID:")
 					if err != nil {
-						cprint.Error(cmd, err)
+						printer.Error(cmd, err)
 						return ""
 					}
 
@@ -285,7 +287,7 @@ func getAppID(cmd *cobra.Command, appName string) string {
 					if err == nil {
 						return appAlternateId
 					}
-					cprint.Warning("Invalid app ID. Please try again.")
+					printer.Warning("Invalid app ID. Please try again.")
 				}
 			}
 		} else {
@@ -300,10 +302,10 @@ func generateDefaultAppId(appName string) string {
 }
 
 func printInitializationSummary(appName, appAlternateId, appID, orgID string) {
-	cprint.Success("App successfully initialized")
-	cprint.Print("") // Print an empty line for spacing
-	cprint.PrintDetail("App Name", appName)
-	cprint.PrintDetail("App AlternateId", appAlternateId)
-	cprint.PrintDetail("App ID", appID)
-	cprint.PrintDetail("Organization ID", orgID)
+	printer.Success("App successfully initialized")
+	printer.Print("") // Print an empty line for spacing
+	printer.PrintDetail("App Name", appName)
+	printer.PrintDetail("App AlternateId", appAlternateId)
+	printer.PrintDetail("App ID", appID)
+	printer.PrintDetail("Organization ID", orgID)
 }

--- a/cmd/link/link.go
+++ b/cmd/link/link.go
@@ -49,6 +49,7 @@ Use 'hyphen link --help' for more information about available flags.
 `,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		printer = cprint.NewCPrinter(flags.VerboseFlag)
 		service := newService(zelda.NewService())
 
 		orgId, err := flags.GetOrganizationID()
@@ -158,7 +159,6 @@ func init() {
 	LinkCmd.Flags().StringArrayVar(&tags, "tag", []string{}, "Tags for the shortened URL. Can be specified multiple times")
 	LinkCmd.Flags().StringVar(&code, "code", "", "Custom short code")
 	LinkCmd.Flags().StringVar(&title, "title", "", "Title for the shortened URL")
-	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }
 
 type service struct {

--- a/cmd/project/create/create.go
+++ b/cmd/project/create/create.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var printer *cprint.CPrinter
+
 var ProjectCreateCmd = &cobra.Command{
 	Use:   "create [name]",
 	Short: "Create a new project in your organization",
@@ -47,7 +49,7 @@ This will create a project named "My New Project" with an alternate ID like "my-
 	Run: func(cmd *cobra.Command, args []string) {
 		orgId, err := flags.GetOrganizationID()
 		if err != nil {
-			cprint.Error(cmd, fmt.Errorf("failed to get organization ID: %w", err))
+			printer.Error(cmd, fmt.Errorf("failed to get organization ID: %w", err))
 			return
 		}
 
@@ -75,14 +77,18 @@ This will create a project named "My New Project" with an alternate ID like "my-
 		// Call the service to create the project
 		newProject, err := service.CreateProject(project)
 		if err != nil {
-			cprint.Error(cmd, fmt.Errorf("failed to create project: %w", err))
+			printer.Error(cmd, fmt.Errorf("failed to create project: %w", err))
 			return
 		}
 
-		cprint.GreenPrint(fmt.Sprintf("Project '%s' created successfully!", name))
+		printer.GreenPrint(fmt.Sprintf("Project '%s' created successfully!", name))
 
-		cprint.PrintDetail("Name", newProject.Name)
-		cprint.PrintDetail("ID", *newProject.ID)
-		cprint.PrintDetail("AlternateID", newProject.AlternateID)
+		printer.PrintDetail("Name", newProject.Name)
+		printer.PrintDetail("ID", *newProject.ID)
+		printer.PrintDetail("AlternateID", newProject.AlternateID)
 	},
+}
+
+func init() {
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }

--- a/cmd/project/create/create.go
+++ b/cmd/project/create/create.go
@@ -47,6 +47,8 @@ This will create a project named "My New Project" with an alternate ID like "my-
 `,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		printer = cprint.NewCPrinter(flags.VerboseFlag)
+
 		orgId, err := flags.GetOrganizationID()
 		if err != nil {
 			printer.Error(cmd, fmt.Errorf("failed to get organization ID: %w", err))
@@ -87,8 +89,4 @@ This will create a project named "My New Project" with an alternate ID like "my-
 		printer.PrintDetail("ID", *newProject.ID)
 		printer.PrintDetail("AlternateID", newProject.AlternateID)
 	},
-}
-
-func init() {
-	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }

--- a/cmd/project/get/get.go
+++ b/cmd/project/get/get.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var printer *cprint.CPrinter
+
 var ProjectGetCmd = &cobra.Command{
 	Use:   "get [project_id]",
 	Short: "Get a project by ID",
@@ -40,19 +42,23 @@ Note: Make sure you have the necessary permissions to access the project informa
 		projectID := args[0]
 		orgId, err := flags.GetOrganizationID()
 		if err != nil {
-			cprint.Error(cmd, fmt.Errorf("failed to get organization ID: %w", err))
+			printer.Error(cmd, fmt.Errorf("failed to get organization ID: %w", err))
 			return
 		}
 
 		service := projects.NewService(orgId)
 		project, err := service.GetProject(projectID)
 		if err != nil {
-			cprint.Error(cmd, fmt.Errorf("failed to get project: %w", err))
+			printer.Error(cmd, fmt.Errorf("failed to get project: %w", err))
 			return
 		}
 
-		cprint.PrintDetail("Name", project.Name)
-		cprint.PrintDetail("ID", *project.ID)
-		cprint.PrintDetail("AlternateID", project.AlternateID)
+		printer.PrintDetail("Name", project.Name)
+		printer.PrintDetail("ID", *project.ID)
+		printer.PrintDetail("AlternateID", project.AlternateID)
 	},
+}
+
+func init() {
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }

--- a/cmd/project/get/get.go
+++ b/cmd/project/get/get.go
@@ -39,6 +39,7 @@ Note: Make sure you have the necessary permissions to access the project informa
 `,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		printer = cprint.NewCPrinter(flags.VerboseFlag)
 		projectID := args[0]
 		orgId, err := flags.GetOrganizationID()
 		if err != nil {
@@ -57,8 +58,4 @@ Note: Make sure you have the necessary permissions to access the project informa
 		printer.PrintDetail("ID", *project.ID)
 		printer.PrintDetail("AlternateID", project.AlternateID)
 	},
-}
-
-func init() {
-	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }

--- a/cmd/project/list/list.go
+++ b/cmd/project/list/list.go
@@ -42,6 +42,8 @@ This command does not accept any arguments. Use it to get a quick overview of al
 Note: The list is fetched based on your current organization context. Ensure you're in the correct organization before running this command.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		printer = cprint.NewCPrinter(flags.VerboseFlag)
+
 		orgId, err := flags.GetOrganizationID()
 		if err != nil {
 			printer.Error(cmd, fmt.Errorf("failed to get organization ID: %w", err))
@@ -68,8 +70,4 @@ Note: The list is fetched based on your current organization context. Ensure you
 		}
 
 	},
-}
-
-func init() {
-	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }

--- a/cmd/project/list/list.go
+++ b/cmd/project/list/list.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var printer *cprint.CPrinter
+
 var ProjectListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all projects",
@@ -42,27 +44,32 @@ Note: The list is fetched based on your current organization context. Ensure you
 	Run: func(cmd *cobra.Command, args []string) {
 		orgId, err := flags.GetOrganizationID()
 		if err != nil {
-			cprint.Error(cmd, fmt.Errorf("failed to get organization ID: %w", err))
+			printer.Error(cmd, fmt.Errorf("failed to get organization ID: %w", err))
 			return
 		}
 
 		service := projects.NewService(orgId)
 		projects, err := service.ListProjects()
 		if err != nil {
-			cprint.Error(cmd, fmt.Errorf("failed to list projects: %w", err))
+			printer.Error(cmd, fmt.Errorf("failed to list projects: %w", err))
 			return
 		}
 
 		if len(projects) == 0 {
-			cprint.YellowPrint("No projects found")
+			printer.YellowPrint("No projects found")
 			return
 		}
 
 		for _, project := range projects {
-			cprint.PrintDetail("Name", project.Name)
-			cprint.PrintDetail("ID", *project.ID)
-			cprint.PrintDetail("AlternateID", project.AlternateID)
-			cprint.Print("")
+			printer.PrintDetail("Name", project.Name)
+			printer.PrintDetail("ID", *project.ID)
+			printer.PrintDetail("AlternateID", project.AlternateID)
+			printer.Print("")
 		}
+
 	},
+}
+
+func init() {
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }

--- a/cmd/setorg/setorg.go
+++ b/cmd/setorg/setorg.go
@@ -6,11 +6,13 @@ import (
 	"github.com/Hyphen/cli/internal/manifest"
 	"github.com/Hyphen/cli/internal/projects"
 	"github.com/Hyphen/cli/pkg/cprint"
+	"github.com/Hyphen/cli/pkg/flags"
 	"github.com/spf13/cobra"
 )
 
 var (
 	globalFlag bool
+	printer    *cprint.CPrinter
 )
 
 var SetOrgCmd = &cobra.Command{
@@ -57,20 +59,21 @@ var SetOrgCmd = &cobra.Command{
 
 func init() {
 	SetOrgCmd.Flags().BoolVar(&globalFlag, "global", false, "Set the organization ID globally")
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }
 
 func printOrgUpdateSuccess(orgID string, isGlobal bool) {
-	cprint.PrintHeader("--- Organization Update ---")
+	printer.PrintHeader("--- Organization Update ---")
 	if isGlobal {
-		cprint.Success("Successfully updated global organization ID")
+		printer.Success("Successfully updated global organization ID")
 	} else {
-		cprint.Success("Successfully updated organization ID")
+		printer.Success("Successfully updated organization ID")
 	}
-	cprint.PrintDetail("New Organization ID", orgID)
+	printer.PrintDetail("New Organization ID", orgID)
 	fmt.Println()
 	if isGlobal {
-		cprint.GreenPrint("Hyphen CLI is now set to use the new organization globally.")
+		printer.GreenPrint("Hyphen CLI is now set to use the new organization globally.")
 	} else {
-		cprint.GreenPrint("Hyphen CLI is now set to use the new organization.")
+		printer.GreenPrint("Hyphen CLI is now set to use the new organization.")
 	}
 }

--- a/cmd/setorg/setorg.go
+++ b/cmd/setorg/setorg.go
@@ -21,6 +21,7 @@ var SetOrgCmd = &cobra.Command{
 	Long:  `Set the organization ID for the Hyphen CLI to use.`,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		printer = cprint.NewCPrinter(flags.VerboseFlag)
 		orgID := args[0]
 		var err error
 
@@ -59,7 +60,6 @@ var SetOrgCmd = &cobra.Command{
 
 func init() {
 	SetOrgCmd.Flags().BoolVar(&globalFlag, "global", false, "Set the organization ID globally")
-	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }
 
 func printOrgUpdateSuccess(orgID string, isGlobal bool) {

--- a/cmd/setproject/setproject.go
+++ b/cmd/setproject/setproject.go
@@ -20,6 +20,7 @@ var SetProjectCmd = &cobra.Command{
 	Long:  `Set the project ID for the Hyphen CLI to use.`,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		printer = cprint.NewCPrinter(flags.VerboseFlag)
 		projectID := args[0]
 		var err error
 
@@ -39,7 +40,6 @@ var SetProjectCmd = &cobra.Command{
 
 func init() {
 	SetProjectCmd.Flags().BoolVar(&globalFlag, "global", false, "Set the project ID globally")
-	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }
 
 func printProjectUpdateSuccess(projectID string, isGlobal bool) {

--- a/cmd/setproject/setproject.go
+++ b/cmd/setproject/setproject.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/Hyphen/cli/internal/manifest"
 	"github.com/Hyphen/cli/pkg/cprint"
+	"github.com/Hyphen/cli/pkg/flags"
 	"github.com/spf13/cobra"
 )
 
 var (
 	globalFlag bool
+	printer    *cprint.CPrinter
 )
 
 var SetProjectCmd = &cobra.Command{
@@ -37,20 +39,21 @@ var SetProjectCmd = &cobra.Command{
 
 func init() {
 	SetProjectCmd.Flags().BoolVar(&globalFlag, "global", false, "Set the project ID globally")
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }
 
 func printProjectUpdateSuccess(projectID string, isGlobal bool) {
-	cprint.PrintHeader("--- Project Update ---")
+	printer.PrintHeader("--- Project Update ---")
 	if isGlobal {
-		cprint.Success("Successfully updated global project ID")
+		printer.Success("Successfully updated global project ID")
 	} else {
-		cprint.Success("Successfully updated project ID")
+		printer.Success("Successfully updated project ID")
 	}
-	cprint.PrintDetail("New Project ID", projectID)
+	printer.PrintDetail("New Project ID", projectID)
 	fmt.Println()
 	if isGlobal {
-		cprint.GreenPrint("Hyphen CLI is now set to use the new project globally.")
+		printer.GreenPrint("Hyphen CLI is now set to use the new project globally.")
 	} else {
-		cprint.GreenPrint("Hyphen CLI is now set to use the new project.")
+		printer.GreenPrint("Hyphen CLI is now set to use the new project.")
 	}
 }

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -85,6 +85,7 @@ var UpdateCmd = &cobra.Command{
 	Long:  `This command updates the Hyphen CLI to the specified version or the latest version available for your operating system`,
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
+		printer = cprint.NewCPrinter(flags.VerboseFlag)
 		updater := NewDefaultUpdater(version)
 		updater.Run(cmd, args)
 	},
@@ -286,7 +287,6 @@ func defaultGetExecutablePath() string {
 
 func init() {
 	UpdateCmd.Flags().StringVar(&version, "version", "", "Specific version to update to (default is latest)")
-	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }
 
 var version string

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -14,6 +14,7 @@ import (
 	cliVersion "github.com/Hyphen/cli/cmd/version"
 	"github.com/Hyphen/cli/pkg/apiconf"
 	"github.com/Hyphen/cli/pkg/cprint"
+	"github.com/Hyphen/cli/pkg/flags"
 	"github.com/fatih/color"
 
 	"github.com/spf13/cobra"
@@ -76,6 +77,8 @@ const (
 
 var validOs = []string{linux, macos, macosArm, windows}
 
+var printer *cprint.CPrinter
+
 var UpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Update the Hyphen CLI",
@@ -110,13 +113,13 @@ func NewDefaultUpdater(version string) *Updater {
 func (u *Updater) Run(cmd *cobra.Command, args []string) {
 	osType := u.DetectPlatform()
 	if !isValidOs(osType) {
-		cprint.Error(cmd, fmt.Errorf("Unsupported operating system: %s", osType))
+		printer.Error(cmd, fmt.Errorf("Unsupported operating system: %s", osType))
 		return
 	}
 
 	latestVersion, err := u.fetchLatestVersion()
 	if err != nil {
-		cprint.Error(cmd, fmt.Errorf("Failed to fetch the latest version: %v\n", err))
+		printer.Error(cmd, fmt.Errorf("Failed to fetch the latest version: %v\n", err))
 		return
 	}
 
@@ -129,7 +132,7 @@ func (u *Updater) Run(cmd *cobra.Command, args []string) {
 	updateUrl := fmt.Sprintf(u.URLTemplate, targetVersion, osType)
 	err = u.DownloadAndUpdate(updateUrl)
 	if err != nil {
-		cprint.Error(cmd, fmt.Errorf("Failed to update Hyphen CLI: %v\n", err))
+		printer.Error(cmd, fmt.Errorf("Failed to update Hyphen CLI: %v\n", err))
 		return
 	}
 	printUpdateSummary(cliVersion.GetVersion(), latestVersion, osType)
@@ -283,6 +286,7 @@ func defaultGetExecutablePath() string {
 
 func init() {
 	UpdateCmd.Flags().StringVar(&version, "version", "", "Specific version to update to (default is latest)")
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }
 
 var version string
@@ -295,18 +299,18 @@ var (
 )
 
 func printIsLatestVersion(currentVersion string) {
-	cprint.PrintHeader("--- Update Check ---")
-	cprint.Success("You are already using the latest version of Hyphen CLI.")
-	cprint.PrintDetail("Current version", currentVersion)
+	printer.PrintHeader("--- Update Check ---")
+	printer.Success("You are already using the latest version of Hyphen CLI.")
+	printer.PrintDetail("Current version", currentVersion)
 }
 
 func printUpdateSummary(currentVersion, latestVersion, osType string) {
-	cprint.PrintHeader("--- Update Summary ---")
-	cprint.Success("Successfully updated Hyphen CLI")
-	cprint.PrintDetail("Previous version", currentVersion)
-	cprint.PrintDetail("New version", latestVersion)
-	cprint.PrintDetail("Platform", osType)
-	cprint.PrintDetail("Update method", "In-place update")
+	printer.PrintHeader("--- Update Summary ---")
+	printer.Success("Successfully updated Hyphen CLI")
+	printer.PrintDetail("Previous version", currentVersion)
+	printer.PrintDetail("New version", latestVersion)
+	printer.PrintDetail("Platform", osType)
+	printer.PrintDetail("Update method", "In-place update")
 	fmt.Println()
-	cprint.GreenPrint("Hyphen CLI is now up-to-date and ready for use.")
+	printer.GreenPrint("Hyphen CLI is now up-to-date and ready for use.")
 }

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -2,11 +2,13 @@ package version
 
 import (
 	"github.com/Hyphen/cli/pkg/cprint"
+	"github.com/Hyphen/cli/pkg/flags"
 	"github.com/spf13/cobra"
 )
 
 // Version is set via ldflags
 var Version string
+var printer *cprint.CPrinter
 
 var VersionCmd = &cobra.Command{
 	Use:   "version",
@@ -20,8 +22,8 @@ var VersionCmd = &cobra.Command{
 
 func printVersionInfo() {
 	version := GetVersion()
-	cprint.PrintHeader("Hyphen Version Information")
-	cprint.PrintDetail("Version", version)
+	printer.PrintHeader("Hyphen Version Information")
+	printer.PrintDetail("Version", version)
 }
 
 // GetVersion returns the current version of the CLI
@@ -30,4 +32,8 @@ func GetVersion() string {
 		Version = "unknown" // Default if not set by ldflags
 	}
 	return Version
+}
+
+func init() {
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -16,6 +16,7 @@ var VersionCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Long:  `All software has versions. This is Hyphen's`,
 	Run: func(cmd *cobra.Command, args []string) {
+		printer = cprint.NewCPrinter(flags.VerboseFlag)
 		printVersionInfo()
 	},
 }
@@ -32,8 +33,4 @@ func GetVersion() string {
 		Version = "unknown" // Default if not set by ldflags
 	}
 	return Version
-}
-
-func init() {
-	printer = cprint.NewCPrinter(flags.VerboseFlag)
 }

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -232,6 +232,15 @@ func RestoreFromFile(manifestConfigFile, manifestSecretFile string) (Manifest, e
 	}, nil
 }
 
+func RestoreGlobalConfig() (Config, error) {
+	globalConfigFile := fmt.Sprintf("%s/%s", GetGlobalDirectory(), ManifestConfigFile)
+	return readAndUnmarshalConfigJSON[Config](globalConfigFile)
+}
+
+func RestoreLocalConfig() (Config, error) {
+	return readAndUnmarshalConfigJSON[Config](ManifestConfigFile)
+}
+
 func readAndUnmarshalConfigJSON[T any](filename string) (T, error) {
 	var result T
 

--- a/pkg/cprint/cprint.go
+++ b/pkg/cprint/cprint.go
@@ -3,7 +3,6 @@ package cprint
 import (
 	"fmt"
 
-	"github.com/Hyphen/cli/pkg/flags"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
@@ -16,9 +15,21 @@ var (
 	red    = color.New(color.FgRed, color.Bold).SprintFunc()
 )
 
-// Error prints an error message in red
-func Error(cmd *cobra.Command, err error) {
-	if flags.VerboseFlag {
+// CPrinter holds the configuration for printing
+type CPrinter struct {
+	verbose bool
+}
+
+// NewCPrinter creates a new CPrinter instance
+func NewCPrinter(verbose bool) *CPrinter {
+	return &CPrinter{
+		verbose: verbose,
+	}
+}
+
+// Standalone functions
+func Error(cmd *cobra.Command, err error, verbose bool) {
+	if verbose {
 		errorDetails := color.New(color.FgWhite).SprintFunc()
 		cmd.PrintErrf("%s %s\n", red("ERROR:"), errorDetails(err.Error()))
 	} else {
@@ -26,65 +37,60 @@ func Error(cmd *cobra.Command, err error) {
 	}
 }
 
-// Info prints an informational message
-func Info(message string) {
-	if flags.VerboseFlag {
+func Info(message string, verbose bool) {
+	if verbose {
 		fmt.Printf("%s %s\n", cyan("ℹ"), white(message))
 	} else {
 		fmt.Println(message)
 	}
 }
 
-func YellowPrint(message string) {
-	if flags.VerboseFlag {
+func YellowPrint(message string, verbose bool) {
+	if verbose {
 		fmt.Printf("%s\n", yellow(message))
 	} else {
 		fmt.Println(message)
 	}
 }
 
-func GreenPrint(message string) {
-	if flags.VerboseFlag {
+func GreenPrint(message string, verbose bool) {
+	if verbose {
 		fmt.Printf("%s\n", green(message))
 	} else {
 		fmt.Println(message)
 	}
 }
 
-func Print(message string) {
-	if flags.VerboseFlag {
+func Print(message string, verbose bool) {
+	if verbose {
 		fmt.Printf("%s\n", white(message))
 	} else {
 		fmt.Println(message)
 	}
 }
 
-// PrintNorm prints a normal message without any special formatting or symbols
 func PrintNorm(message string) {
 	fmt.Println(message)
 }
 
-// Success prints a success message
-func Success(message string) {
-	if flags.VerboseFlag {
+func Success(message string, verbose bool) {
+	if verbose {
 		fmt.Printf("%s %s\n", green("✅"), white(message))
 	} else {
 		fmt.Println(message)
 	}
 }
 
-// Warning prints a warning message
-func Warning(message string) {
-	if flags.VerboseFlag {
+func Warning(message string, verbose bool) {
+	if verbose {
 		fmt.Printf("%s %s\n", yellow("⚠"), white(message))
 	} else {
 		fmt.Println("WARNING:", message)
 	}
 }
 
-// OrganizationInfo prints organization information
-func OrganizationInfo(orgID string) {
-	if flags.VerboseFlag {
+func OrganizationInfo(orgID string, verbose bool) {
+	if verbose {
 		fmt.Printf("\n%s\n", white("Organization Information:"))
 		fmt.Printf("  %s %s\n", white("ID:"), cyan(orgID))
 	} else {
@@ -92,29 +98,75 @@ func OrganizationInfo(orgID string) {
 	}
 }
 
-// Prompt prints a prompt message
-func Prompt(message string) {
-	if flags.VerboseFlag {
+func Prompt(message string, verbose bool) {
+	if verbose {
 		fmt.Print(yellow(message))
 	} else {
 		fmt.Print(message)
 	}
 }
 
-// PrintHeader prints a header
-func PrintHeader(message string) {
-	if flags.VerboseFlag {
+func PrintHeader(message string, verbose bool) {
+	if verbose {
 		fmt.Printf("\n%s\n", yellow(message))
 	} else {
 		fmt.Println(message)
 	}
 }
 
-// PrintDetail prints a detail line
-func PrintDetail(label, value string) {
-	if flags.VerboseFlag {
+func PrintDetail(label, value string, verbose bool) {
+	if verbose {
 		fmt.Printf("   %s %s\n", white(label+":"), cyan(value))
 	} else {
 		fmt.Printf("%s: %s\n", label, value)
 	}
+}
+
+// CPrinter methods
+func (p *CPrinter) Error(cmd *cobra.Command, err error) {
+	Error(cmd, err, p.verbose)
+}
+
+func (p *CPrinter) Info(message string) {
+	Info(message, p.verbose)
+}
+
+func (p *CPrinter) YellowPrint(message string) {
+	YellowPrint(message, p.verbose)
+}
+
+func (p *CPrinter) GreenPrint(message string) {
+	GreenPrint(message, p.verbose)
+}
+
+func (p *CPrinter) Print(message string) {
+	Print(message, p.verbose)
+}
+
+func (p *CPrinter) PrintNorm(message string) {
+	PrintNorm(message)
+}
+
+func (p *CPrinter) Success(message string) {
+	Success(message, p.verbose)
+}
+
+func (p *CPrinter) Warning(message string) {
+	Warning(message, p.verbose)
+}
+
+func (p *CPrinter) OrganizationInfo(orgID string) {
+	OrganizationInfo(orgID, p.verbose)
+}
+
+func (p *CPrinter) Prompt(message string) {
+	Prompt(message, p.verbose)
+}
+
+func (p *CPrinter) PrintHeader(message string) {
+	PrintHeader(message, p.verbose)
+}
+
+func (p *CPrinter) PrintDetail(label, value string) {
+	PrintDetail(label, value, p.verbose)
 }

--- a/pkg/flags/organization.go
+++ b/pkg/flags/organization.go
@@ -28,15 +28,12 @@ func GetOrganizationID() (string, error) {
 }
 
 func isGlobalOrgIdSameAsLocal() bool {
-	ml, err := manifest.RestoreLocalConfig()
-	if err != nil {
-		return false
+	ml, _ := manifest.RestoreLocalConfig() // we can skip the error, if its new project will no have ml
+	if ml.OrganizationId == "" {
+		return true //if we dont have ml return true bc is new project
 	}
 
-	mg, err := manifest.RestoreGlobalConfig()
-	if err != nil {
-		return false
-	}
+	mg, _ := manifest.RestoreGlobalConfig() // we can skip this error check, bc whe check the error in the line  16
 
 	if ml.OrganizationId != mg.OrganizationId {
 		return false

--- a/pkg/flags/organization.go
+++ b/pkg/flags/organization.go
@@ -2,7 +2,6 @@ package flags
 
 import (
 	"github.com/Hyphen/cli/internal/manifest"
-	"github.com/Hyphen/cli/pkg/cprint"
 	"github.com/Hyphen/cli/pkg/errors"
 )
 
@@ -11,33 +10,14 @@ func GetOrganizationID() (string, error) {
 		return OrganizationFlag, nil
 	}
 
-	m, err := manifest.RestoreConfig()
+	manifest, err := manifest.RestoreConfig()
 	if err != nil {
 		return "", err
 	}
 
-	if m.OrganizationId == "" {
+	if manifest.OrganizationId == "" {
 		return "", errors.New("No organization ID provided and no default found in manifest")
 	}
 
-	if !isGlobalOrgIdSameAsLocal() {
-		cprint.Warning("The app organization ID is different from the global organization ID. This could lead to unexpected behavior.", VerboseFlag)
-	}
-
-	return m.OrganizationId, nil
-}
-
-func isGlobalOrgIdSameAsLocal() bool {
-	ml, _ := manifest.RestoreLocalConfig() // we can skip the error, if its new project will no have ml
-	if ml.OrganizationId == "" {
-		return true //if we dont have ml return true bc is new project
-	}
-
-	mg, _ := manifest.RestoreGlobalConfig() // we can skip this error check, bc whe check the error in the line  16
-
-	if ml.OrganizationId != mg.OrganizationId {
-		return false
-	}
-
-	return true
+	return manifest.OrganizationId, nil
 }

--- a/pkg/flags/organization.go
+++ b/pkg/flags/organization.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	"github.com/Hyphen/cli/internal/manifest"
+	"github.com/Hyphen/cli/pkg/cprint"
 	"github.com/Hyphen/cli/pkg/errors"
 )
 
@@ -10,14 +11,36 @@ func GetOrganizationID() (string, error) {
 		return OrganizationFlag, nil
 	}
 
-	manifest, err := manifest.RestoreConfig()
+	m, err := manifest.RestoreConfig()
 	if err != nil {
 		return "", err
 	}
 
-	if manifest.OrganizationId == "" {
+	if m.OrganizationId == "" {
 		return "", errors.New("No organization ID provided and no default found in manifest")
 	}
 
-	return manifest.OrganizationId, nil
+	if !isGlobalOrgIdSameAsLocal() {
+		cprint.Warning("The app organization ID is different from the global organization ID. This could lead to unexpected behavior.", VerboseFlag)
+	}
+
+	return m.OrganizationId, nil
+}
+
+func isGlobalOrgIdSameAsLocal() bool {
+	ml, err := manifest.RestoreLocalConfig()
+	if err != nil {
+		return false
+	}
+
+	mg, err := manifest.RestoreGlobalConfig()
+	if err != nil {
+		return false
+	}
+
+	if ml.OrganizationId != mg.OrganizationId {
+		return false
+	}
+
+	return true
 }

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -8,9 +8,16 @@ import (
 	"syscall"
 
 	"github.com/Hyphen/cli/pkg/cprint"
+	"github.com/Hyphen/cli/pkg/flags"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
+
+var printer *cprint.CPrinter
+
+func init() {
+	printer = cprint.NewCPrinter(flags.VerboseFlag)
+}
 
 type Response struct {
 	Confirmed bool
@@ -45,7 +52,7 @@ func PromptYesNo(cmd *cobra.Command, prompt string, defaultValue bool) Response 
 	case "":
 		return Response{Confirmed: defaultValue, IsFlag: false}
 	default:
-		cprint.Warning("Invalid response. Please enter 'y' or 'n'.")
+		printer.Warning("Invalid response. Please enter 'y' or 'n'.")
 		return PromptYesNo(cmd, prompt, defaultValue)
 	}
 }


### PR DESCRIPTION
There was a circular dependency between cprint and flags. I needed to use cprint in flags, so I refactored cprint.