### PR TITLE
feat: add organization ID check in pkg/flags/organization.go

### DIFF
--- a/pkg/flags/organization.go
+++ b/pkg/flags/organization.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	"github.com/Hyphen/cli/internal/manifest"
+	"github.com/Hyphen/cli/pkg/cprint"
 	"github.com/Hyphen/cli/pkg/errors"
 )
 
@@ -10,14 +11,33 @@ func GetOrganizationID() (string, error) {
 		return OrganizationFlag, nil
 	}
 
-	manifest, err := manifest.RestoreConfig()
+	m, err := manifest.RestoreConfig()
 	if err != nil {
 		return "", err
 	}
 
-	if manifest.OrganizationId == "" {
+	if m.OrganizationId == "" {
 		return "", errors.New("No organization ID provided and no default found in manifest")
 	}
 
-	return manifest.OrganizationId, nil
+	if !isGlobalOrgIdSameAsLocal() {
+		cprint.Warning("The app organization ID is different from the global organization ID. This could lead to unexpected behavior.", VerboseFlag)
+	}
+
+	return m.OrganizationId, nil
+}
+
+func isGlobalOrgIdSameAsLocal() bool {
+	ml, _ := manifest.RestoreLocalConfig() // we can skip the error, if its new project will no have ml
+	if ml.OrganizationId == "" {
+		return true //if we dont have ml return true bc is new project
+	}
+
+	mg, _ := manifest.RestoreGlobalConfig() // we can skip this error check, bc whe check the error in the line  16
+
+	if ml.OrganizationId != mg.OrganizationId {
+		return false
+	}
+
+	return true
 }


### PR DESCRIPTION
This commit includes an enhanced check for validating the organization ID in the 'pkg/flags/organization.go' file. A new function 'isGlobalOrgIdSameAsLocal' is added to facilitate this feature. A warning message is displayed if the app organization ID differs from the global organization ID to prevent unexpected behavior.