### PR TITLE
feat: Improved error handling and conflict resolution in initialize.go

### DIFF
--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -58,7 +58,30 @@ func (m *Manifest) GetSecretKey() *secretkey.SecretKey {
 }
 
 func LocalInitialize(mc Config) (Manifest, error) {
-	return Initialize(mc, ManifestSecretFile, ManifestConfigFile)
+	err := InitializeConfig(mc, ManifestConfigFile)
+	if err != nil {
+		return Manifest{}, errors.Wrap(err, "Failed to initialize manifest config")
+	}
+
+	var ms Secret
+	if _, err := os.Stat(ManifestSecretFile); err == nil {
+		ms, err = RestoreSecretFromFile(ManifestSecretFile)
+		if err != nil {
+			return Manifest{}, errors.Wrap(err, "Failed to restore manifest secret from file")
+		}
+	} else {
+		ms, err = InitializeSecret(ManifestSecretFile)
+		if err != nil {
+			return Manifest{}, errors.Wrap(err, "Failed to initialize manifest secret")
+		}
+	}
+
+	m := Manifest{
+		mc,
+		ms,
+	}
+
+	return m, nil
 }
 
 func GlobalInitializeConfig(mc Config) error {


### PR DESCRIPTION
This commit introduces refined error handling in cmd/initialize/initialize.go, distinguishing between regular errors and conflict errors. New functionality has been added to handle conflict errors when the application already exists and resolving conflicts when pushing environment files.

In addition, the initialization process has been enhanced in internal/manifest/manifest.go, checking for existing manifest configs and secrets before initializing, thereby preventing any unnecessary operations and potential errors.