### PR TITLE
feat: monorepo

### DIFF
--- a/cmd/env/push/push.go
+++ b/cmd/env/push/push.go
@@ -2,6 +2,7 @@ package push
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/Hyphen/cli/internal/database"
@@ -54,6 +55,54 @@ func RunPush(args []string, secretKeyId int64) error {
 		return err
 	}
 
+	// Check if this is a monorepo
+	if manifest.IsMonorepoProject() && manifest.Project != nil {
+		// Store current directory
+		currentDir, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get current directory: %w", err)
+		}
+
+		// Push for each workspace member
+		for _, memberDir := range manifest.Project.Apps {
+			if !Silent {
+				printer.Print(fmt.Sprintf("Pushing for workspace member: %s", memberDir))
+			}
+
+			// Change to member directory
+			err = os.Chdir(memberDir)
+			if err != nil {
+				printer.Warning(fmt.Sprintf("Failed to change to directory %s: %s", memberDir, err))
+				continue
+			}
+
+			// Run push for this member
+			err = pushForMember(args, secretKeyId)
+			if err != nil {
+				printer.Warning(fmt.Sprintf("Failed to push for member %s: %s", memberDir, err))
+			}
+
+			// Change back to original directory
+			err = os.Chdir(currentDir)
+			if err != nil {
+				return fmt.Errorf("failed to return to original directory: %w", err)
+			}
+		}
+
+		return nil
+	}
+
+	// If not a monorepo, proceed with regular push
+	return pushForMember(args, secretKeyId)
+}
+
+// pushForMember contains the original push logic
+func pushForMember(args []string, secretKeyId int64) error {
+	manifest, err := manifest.Restore()
+	if err != nil {
+		return err
+	}
+
 	db, err := database.Restore()
 	if err != nil {
 		return err
@@ -90,6 +139,7 @@ func RunPush(args []string, secretKeyId int64) error {
 	if err := service.checkIfLocalEnvsExistAsEnvironments(envsToPush, orgId, projectId); err != nil {
 		return err
 	}
+
 	for _, envName := range envsToPush {
 		e, err := env.GetLocalEncryptedEnv(envName, nil, manifest)
 		if err != nil {

--- a/cmd/initialize/initlizeMonorepo.go
+++ b/cmd/initialize/initlizeMonorepo.go
@@ -61,6 +61,11 @@ func runInitMonorepo(cmd *cobra.Command, args []string) {
 			continue
 		}
 
+		if _, err := os.Stat(cleanPath); os.IsNotExist(err) {
+			printer.Error(cmd, fmt.Errorf("directory does not exist: %s", cleanPath))
+			continue
+		}
+
 		currentDir, err := os.Getwd()
 		if err != nil {
 			printer.Error(cmd, fmt.Errorf("Failed to get current directory: %w", err))

--- a/cmd/initialize/initlizeMonorepo.go
+++ b/cmd/initialize/initlizeMonorepo.go
@@ -57,13 +57,13 @@ func runInitMonorepo(cmd *cobra.Command, args []string) {
 		cleanPath := filepath.Clean(appPath)
 
 		if strings.HasPrefix(cleanPath, "..") || strings.Contains(cleanPath, "../") {
-			printer.Error(cmd, fmt.Errorf("invalid path: cannot reference parent directories"))
+			printer.Error(cmd, fmt.Errorf("Invalid path: cannot reference parent directories"))
 			continue
 		}
 
 		currentDir, err := os.Getwd()
 		if err != nil {
-			printer.Error(cmd, fmt.Errorf("failed to get current directory: %w", err))
+			printer.Error(cmd, fmt.Errorf("Failed to get current directory: %w", err))
 			return
 		}
 
@@ -75,14 +75,14 @@ func runInitMonorepo(cmd *cobra.Command, args []string) {
 
 		// Ensure the path is under current directory
 		if !strings.HasPrefix(absPath, currentDir) {
-			printer.Error(cmd, fmt.Errorf("invalid path: must be within current directory"))
+			printer.Error(cmd, fmt.Errorf("Invalid path: must be within current directory"))
 			continue
 		}
 
 		printer.Info(fmt.Sprintf("Initializing app %s", cleanPath))
 		err = initializeMonorepoApp(cmd, cleanPath, orgID, m.Config, appService, envService, m.Secret)
 		if err != nil {
-			printer.Error(cmd, fmt.Errorf("failed to initialize app %s: %w", cleanPath, err))
+			printer.Error(cmd, fmt.Errorf("Failed to initialize app %s: %w", cleanPath, err))
 			continue
 		}
 
@@ -101,7 +101,7 @@ func initializeMonorepoApp(cmd *cobra.Command, appDir string, orgID string, mc m
 	var appName string
 	if !response.Confirmed {
 		if response.IsFlag {
-			return fmt.Errorf("operation cancelled due to --no flag for app: %s", defaultAppName)
+			return fmt.Errorf("Operation cancelled due to --no flag for app: %s", defaultAppName)
 		}
 
 		// Prompt for a new app name
@@ -125,7 +125,7 @@ func initializeMonorepoApp(cmd *cobra.Command, appDir string, orgID string, mc m
 
 		if !response.Confirmed {
 			if response.IsFlag {
-				return fmt.Errorf("operation cancelled due to --no flag for app ID: %s", defaultAppAlternateId)
+				return fmt.Errorf("Operation cancelled due to --no flag for app ID: %s", defaultAppAlternateId)
 			}
 
 			// Prompt for a custom app ID
@@ -161,7 +161,7 @@ func initializeMonorepoApp(cmd *cobra.Command, appDir string, orgID string, mc m
 			return handleErr
 		}
 		if existingApp == nil {
-			return fmt.Errorf("operation cancelled for app: %s", appName)
+			return fmt.Errorf("Operation cancelled for app: %s", appName)
 		}
 
 		newApp = *existingApp
@@ -229,7 +229,7 @@ func CreateAndPushEmptyEnvFileMonorepo(cmd *cobra.Command, envService *env.EnvSe
 
 	// Ensure the directory exists
 	if err := os.MkdirAll(appDir, 0755); err != nil {
-		return fmt.Errorf("failed to create directory %s: %w", appDir, err)
+		return fmt.Errorf("Failed to create directory %s: %w", appDir, err)
 	}
 
 	err = CreateGitignoredFileMonorepo(cmd, fullEnvPath, envFileName)
@@ -274,7 +274,7 @@ func CreateAndPushEmptyEnvFileMonorepo(cmd *cobra.Command, envService *env.EnvSe
 	}
 
 	if err := db.UpsertSecret(secretKey, newEnvDecrypted, version); err != nil {
-		return fmt.Errorf("failed to save local environment: %w", err)
+		return fmt.Errorf("Failed to save local environment: %w", err)
 	}
 
 	return nil
@@ -284,7 +284,7 @@ func CreateGitignoredFileMonorepo(cmd *cobra.Command, fullPath, fileName string)
 	// Ensure the directory exists
 	dir := filepath.Dir(fullPath)
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("failed to create directory %s: %w", dir, err)
+		return fmt.Errorf("Failed to create directory %s: %w", dir, err)
 	}
 
 	// check if the file already exists.
@@ -296,7 +296,7 @@ func CreateGitignoredFileMonorepo(cmd *cobra.Command, fullPath, fileName string)
 	// Create the file
 	file, err := os.Create(fullPath)
 	if err != nil {
-		printer.Error(cmd, fmt.Errorf("error creating %s: %w", fullPath, err))
+		printer.Error(cmd, fmt.Errorf("Error creating %s: %w", fullPath, err))
 		return err
 	}
 	defer file.Close()
@@ -304,12 +304,12 @@ func CreateGitignoredFileMonorepo(cmd *cobra.Command, fullPath, fileName string)
 	// Write '# KEY=Value' to the file
 	_, err = file.WriteString("# Example\n# KEY=Value\n")
 	if err != nil {
-		printer.Error(cmd, fmt.Errorf("error writing to %s: %w", fullPath, err))
+		printer.Error(cmd, fmt.Errorf("Error writing to %s: %w", fullPath, err))
 		return err
 	}
 
 	if err := gitutil.EnsureGitignore(fileName); err != nil {
-		printer.Error(cmd, fmt.Errorf("error adding %s to .gitignore: %w. Please do this manually if you wish", fileName, err))
+		printer.Error(cmd, fmt.Errorf("Error adding %s to .gitignore: %w. Please do this manually if you wish", fileName, err))
 		// don't error here. Keep going.
 	}
 

--- a/internal/projects/projects.go
+++ b/internal/projects/projects.go
@@ -11,6 +11,7 @@ type Project struct {
 	ID          *string `json:"id,omitempty"`
 	AlternateID string  `json:"alternateId"`
 	Name        string  `json:"name"`
+	IsMonorepo  bool    `json:"isMonorepo"`
 }
 
 func CheckProjectId(appId string) error {

--- a/pkg/cprint/cprint.go
+++ b/pkg/cprint/cprint.go
@@ -31,62 +31,39 @@ func NewCPrinter(verbose bool) *CPrinter {
 func Error(cmd *cobra.Command, err error, verbose bool) {
 	if verbose {
 		errorDetails := color.New(color.FgWhite).SprintFunc()
-		cmd.PrintErrf("%s %s\n", red("ERROR:"), errorDetails(err.Error()))
+
+		cmd.PrintErrf("%s %s\n", red("❗error - "), errorDetails(err.Error()))
 	} else {
 		fmt.Println("ERROR:", err.Error())
 	}
 }
 
-func Info(message string, verbose bool) {
-	if verbose {
-		fmt.Printf("%s %s\n", cyan("ℹ"), white(message))
-	} else {
-		fmt.Println(message)
-	}
+func Info(message string) {
+	fmt.Printf("%s %s\n", cyan("ℹ"), white(message))
 }
 
-func YellowPrint(message string, verbose bool) {
-	if verbose {
-		fmt.Printf("%s\n", yellow(message))
-	} else {
-		fmt.Println(message)
-	}
+func YellowPrint(message string) {
+	fmt.Printf("%s\n", yellow(message))
 }
 
-func GreenPrint(message string, verbose bool) {
-	if verbose {
-		fmt.Printf("%s\n", green(message))
-	} else {
-		fmt.Println(message)
-	}
+func GreenPrint(message string) {
+	fmt.Printf("%s\n", green(message))
 }
 
-func Print(message string, verbose bool) {
-	if verbose {
-		fmt.Printf("%s\n", white(message))
-	} else {
-		fmt.Println(message)
-	}
+func Print(message string) {
+	fmt.Printf("%s\n", white(message))
 }
 
 func PrintNorm(message string) {
 	fmt.Println(message)
 }
 
-func Success(message string, verbose bool) {
-	if verbose {
-		fmt.Printf("%s %s\n", green("✅"), white(message))
-	} else {
-		fmt.Println(message)
-	}
+func Success(message string) {
+	fmt.Printf("%s %s\n", green("✅"), white(message))
 }
 
-func Warning(message string, verbose bool) {
-	if verbose {
-		fmt.Printf("%s %s\n", yellow("⚠"), white(message))
-	} else {
-		fmt.Println("WARNING:", message)
-	}
+func Warning(message string) {
+	fmt.Printf("%s %s\n", yellow("⚠"), white(message))
 }
 
 func OrganizationInfo(orgID string, verbose bool) {
@@ -99,48 +76,36 @@ func OrganizationInfo(orgID string, verbose bool) {
 }
 
 func Prompt(message string, verbose bool) {
-	if verbose {
-		fmt.Print(yellow(message))
-	} else {
-		fmt.Print(message)
-	}
+	fmt.Print(yellow(message))
 }
 
-func PrintHeader(message string, verbose bool) {
-	if verbose {
-		fmt.Printf("\n%s\n", yellow(message))
-	} else {
-		fmt.Println(message)
-	}
+func PrintHeader(message string) {
+	fmt.Printf("\n%s\n", yellow(message))
 }
 
-func PrintDetail(label, value string, verbose bool) {
-	if verbose {
-		fmt.Printf("   %s %s\n", white(label+":"), cyan(value))
-	} else {
-		fmt.Printf("%s: %s\n", label, value)
-	}
+func PrintDetail(label, value string) {
+	fmt.Printf("   %s %s\n", white(label+":"), cyan(value))
 }
 
 // CPrinter methods
 func (p *CPrinter) Error(cmd *cobra.Command, err error) {
-	Error(cmd, err, p.verbose)
+	Error(cmd, err, true)
 }
 
 func (p *CPrinter) Info(message string) {
-	Info(message, p.verbose)
+	Info(message)
 }
 
 func (p *CPrinter) YellowPrint(message string) {
-	YellowPrint(message, p.verbose)
+	YellowPrint(message)
 }
 
 func (p *CPrinter) GreenPrint(message string) {
-	GreenPrint(message, p.verbose)
+	GreenPrint(message)
 }
 
 func (p *CPrinter) Print(message string) {
-	Print(message, p.verbose)
+	Print(message)
 }
 
 func (p *CPrinter) PrintNorm(message string) {
@@ -148,11 +113,11 @@ func (p *CPrinter) PrintNorm(message string) {
 }
 
 func (p *CPrinter) Success(message string) {
-	Success(message, p.verbose)
+	Success(message) //issues/168 introduce always emoji
 }
 
 func (p *CPrinter) Warning(message string) {
-	Warning(message, p.verbose)
+	Warning(message)
 }
 
 func (p *CPrinter) OrganizationInfo(orgID string) {
@@ -164,9 +129,9 @@ func (p *CPrinter) Prompt(message string) {
 }
 
 func (p *CPrinter) PrintHeader(message string) {
-	PrintHeader(message, p.verbose)
+	PrintHeader(message)
 }
 
 func (p *CPrinter) PrintDetail(label, value string) {
-	PrintDetail(label, value, p.verbose)
+	PrintDetail(label, value)
 }

--- a/pkg/flags/organization.go
+++ b/pkg/flags/organization.go
@@ -21,7 +21,7 @@ func GetOrganizationID() (string, error) {
 	}
 
 	if !isGlobalOrgIdSameAsLocal() {
-		cprint.Warning("The app organization ID is different from the global organization ID. This could lead to unexpected behavior.", VerboseFlag)
+		cprint.Warning("The app organization ID is different from the global organization ID. This could lead to unexpected behavior.")
 	}
 
 	return m.OrganizationId, nil

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -86,7 +86,7 @@ func PromptPassword(cmd *cobra.Command, prompt string) (string, error) {
 	fmt.Print(prompt)
 	noFlag, _ := cmd.Flags().GetBool("no")
 	if noFlag {
-		return "", fmt.Errorf("Oeration cancelled due to --no flag")
+		return "", fmt.Errorf("Operation cancelled due to --no flag")
 	}
 
 	byteKey, err := term.ReadPassword(int(syscall.Stdin))

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -63,7 +63,7 @@ func PromptString(cmd *cobra.Command, prompt string) (string, error) {
 
 	noFlag, _ := cmd.Flags().GetBool("no")
 	if noFlag {
-		return "", fmt.Errorf("operation cancelled due to --no flag")
+		return "", fmt.Errorf("Operation cancelled due to --no flag")
 	}
 
 	reader := bufio.NewReader(os.Stdin)
@@ -86,7 +86,7 @@ func PromptPassword(cmd *cobra.Command, prompt string) (string, error) {
 	fmt.Print(prompt)
 	noFlag, _ := cmd.Flags().GetBool("no")
 	if noFlag {
-		return "", fmt.Errorf("operation cancelled due to --no flag")
+		return "", fmt.Errorf("Oeration cancelled due to --no flag")
 	}
 
 	byteKey, err := term.ReadPassword(int(syscall.Stdin))
@@ -103,7 +103,7 @@ func PromptDir(cmd *cobra.Command, prompt string, mustExist bool) (string, error
 
 	noFlag, _ := cmd.Flags().GetBool("no")
 	if noFlag {
-		return "", fmt.Errorf("operation cancelled due to --no flag")
+		return "", fmt.Errorf("Operation cancelled due to --no flag")
 	}
 
 	reader := bufio.NewReader(os.Stdin)


### PR DESCRIPTION
In the past, we asked for a file and took the apps from that file. Now the interaction is like this:  
-  Provide the path to an application  
> ./packages/api  
-  Do you want to use the name api [Y/n]  
-  Do you have another? [y/n]  
> ./packages/frontend  
-  Do you want to use the name frontend [y/N]  
> website  
-  Do you have another? [y/N]  
