### PR TITLE
feat: Better unauthed error handling

### DIFF
--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Hyphen/cli/cmd/app/create"
 	"github.com/Hyphen/cli/cmd/app/get"
 	"github.com/Hyphen/cli/cmd/app/list"
+	"github.com/Hyphen/cli/internal/user"
 	"github.com/spf13/cobra"
 )
 
@@ -11,6 +12,9 @@ var AppCmd = &cobra.Command{
 	Use:   "app",
 	Short: "Manage applications",
 	Long:  `The app command allows you to manage applications within your organization. You can list, create, and delete applications using the available subcommands.`,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return user.ErrorIfNotAuthenticated()
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		list.ListCmd.Run(cmd, args)
 	},

--- a/cmd/build/build.go
+++ b/cmd/build/build.go
@@ -3,6 +3,7 @@ package build
 import (
 	"github.com/Hyphen/cli/internal/build"
 	hyphenapp "github.com/Hyphen/cli/internal/hyphenApp"
+	"github.com/Hyphen/cli/internal/user"
 	"github.com/Hyphen/cli/pkg/cprint"
 	"github.com/Hyphen/cli/pkg/flags"
 	"github.com/spf13/cobra"
@@ -27,6 +28,9 @@ hyphen deploy deploy-dev
 Use 'hyphen link --help' for more information about available flags.
 `,
 	Args: cobra.RangeArgs(0, 1),
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return user.ErrorIfNotAuthenticated()
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		printer = cprint.NewCPrinter(flags.VerboseFlag)
 		service := build.NewService()

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Hyphen/cli/internal/build"
 	Deployment "github.com/Hyphen/cli/internal/deployment"
+	"github.com/Hyphen/cli/internal/user"
 	"github.com/Hyphen/cli/pkg/apiconf"
 	"github.com/Hyphen/cli/pkg/cprint"
 	"github.com/Hyphen/cli/pkg/flags"
@@ -35,6 +36,9 @@ hyphen deploy deploy-dev
 Use 'hyphen deploy --help' for more information about available flags.
 `,
 	Args: cobra.RangeArgs(0, 1),
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return user.ErrorIfNotAuthenticated()
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		orgId, err := flags.GetOrganizationID()
 		if err != nil {

--- a/cmd/env/env.go
+++ b/cmd/env/env.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Hyphen/cli/cmd/env/push"
 	"github.com/Hyphen/cli/cmd/env/rotatekey"
 	"github.com/Hyphen/cli/cmd/env/run"
+	"github.com/Hyphen/cli/internal/user"
 	"github.com/Hyphen/cli/pkg/flags"
 	"github.com/spf13/cobra"
 )
@@ -15,6 +16,9 @@ var EnvCmd = &cobra.Command{
 	Use:   "env",
 	Short: "Manage environment .env secrets",
 	Long:  `Manage environment .env secrets for different environments.`,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return user.ErrorIfNotAuthenticated()
+	},
 }
 
 func init() {

--- a/cmd/initapp/initapp.go
+++ b/cmd/initapp/initapp.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Hyphen/cli/internal/env"
 	hyphenapp "github.com/Hyphen/cli/internal/hyphenApp"
 	"github.com/Hyphen/cli/internal/secret"
+	"github.com/Hyphen/cli/internal/user"
 	"github.com/Hyphen/cli/pkg/cprint"
 	"github.com/Hyphen/cli/pkg/errors"
 	"github.com/Hyphen/cli/pkg/flags"
@@ -51,9 +52,11 @@ Examples:
   hyphen init "My New App" --id my-custom-app-id
 `,
 	Args: cobra.MaximumNArgs(1),
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return user.ErrorIfNotAuthenticated()
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		RunInitApp(cmd, args)
-
 	},
 }
 

--- a/cmd/initialize/initialize.go
+++ b/cmd/initialize/initialize.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/Hyphen/cli/cmd/initapp"
+	"github.com/Hyphen/cli/internal/user"
 	"github.com/Hyphen/cli/pkg/cprint"
 	"github.com/Hyphen/cli/pkg/flags"
 	"github.com/spf13/cobra"
@@ -42,6 +43,9 @@ Examples:
   hyphen init "My New App" --id my-custom-app-id
 `,
 	Args: cobra.MaximumNArgs(1),
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return user.ErrorIfNotAuthenticated()
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if isMonorepo {
 			runInitMonorepo(cmd, args)

--- a/cmd/initproject/initproject.go
+++ b/cmd/initproject/initproject.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Hyphen/cli/internal/config"
 	"github.com/Hyphen/cli/internal/projects"
 	"github.com/Hyphen/cli/internal/secret"
+	"github.com/Hyphen/cli/internal/user"
 	"github.com/Hyphen/cli/pkg/cprint"
 	"github.com/Hyphen/cli/pkg/errors"
 	"github.com/Hyphen/cli/pkg/flags"
@@ -48,6 +49,9 @@ Examples:
   hyphen init-project "My New Project" --id my-custom-project-id
 `,
 	Args: cobra.MaximumNArgs(1),
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return user.ErrorIfNotAuthenticated()
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		RunInitProject(cmd, args)
 	},

--- a/cmd/link/link.go
+++ b/cmd/link/link.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/Hyphen/cli/internal/user"
 	"github.com/Hyphen/cli/internal/zelda"
 	"github.com/Hyphen/cli/pkg/cprint"
 	"github.com/Hyphen/cli/pkg/flags"
@@ -48,6 +49,9 @@ Examples:
 Use 'hyphen link --help' for more information about available flags.
 `,
 	Args: cobra.ExactArgs(1),
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return user.ErrorIfNotAuthenticated()
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		printer = cprint.NewCPrinter(flags.VerboseFlag)
 		service := newService(zelda.NewService())

--- a/cmd/project/project.go
+++ b/cmd/project/project.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Hyphen/cli/cmd/project/create"
 	"github.com/Hyphen/cli/cmd/project/get"
 	"github.com/Hyphen/cli/cmd/project/list"
+	"github.com/Hyphen/cli/internal/user"
 	"github.com/spf13/cobra"
 )
 
@@ -21,6 +22,9 @@ Examples:
   hyphen project get <project_id>
   hyphen project create "New Project"
 `,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return user.ErrorIfNotAuthenticated()
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// check if the subcommand is unsupported
 		// If no subcommand is provided, default to 'list' command

--- a/cmd/setorg/setorg.go
+++ b/cmd/setorg/setorg.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Hyphen/cli/internal/config"
 	"github.com/Hyphen/cli/internal/projects"
+	"github.com/Hyphen/cli/internal/user"
 	"github.com/Hyphen/cli/pkg/cprint"
 	"github.com/Hyphen/cli/pkg/flags"
 	"github.com/spf13/cobra"
@@ -20,6 +21,9 @@ var SetOrgCmd = &cobra.Command{
 	Short: "Set the organization ID",
 	Long:  `Set the organization ID for the Hyphen CLI to use.`,
 	Args:  cobra.ExactArgs(1),
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return user.ErrorIfNotAuthenticated()
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		printer = cprint.NewCPrinter(flags.VerboseFlag)
 		orgID := args[0]

--- a/cmd/setproject/setproject.go
+++ b/cmd/setproject/setproject.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Hyphen/cli/internal/config"
+	"github.com/Hyphen/cli/internal/user"
 	"github.com/Hyphen/cli/pkg/cprint"
 	"github.com/Hyphen/cli/pkg/flags"
 	"github.com/spf13/cobra"
@@ -19,6 +20,9 @@ var SetProjectCmd = &cobra.Command{
 	Short: "Set the project ID",
 	Long:  `Set the project ID for the Hyphen CLI to use.`,
 	Args:  cobra.ExactArgs(1),
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return user.ErrorIfNotAuthenticated()
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		printer = cprint.NewCPrinter(flags.VerboseFlag)
 		projectID := args[0]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 
 	"dario.cat/mergo"
-	"github.com/Hyphen/cli/internal/timeprovider"
 	"github.com/Hyphen/cli/pkg/errors"
 	"github.com/Hyphen/cli/pkg/fsutil"
 )
@@ -35,29 +34,6 @@ type Config struct {
 	IsMonorepo         *bool       `json:"is_monorepo,omitempty"`
 	Project            *Project    `json:"project,omitempty"`
 	Database           interface{} `json:"database,omitempty"`
-}
-
-func IsAuthenticated() (bool, error) {
-	config, err := RestoreConfig()
-	if err != nil {
-		return false, err
-	}
-
-	return config.IsAuthenticated(), nil
-}
-
-func (c *Config) IsAuthenticated() bool {
-	if c.ExpiryTime != nil {
-		// validate it's not expired
-		timeProvider := timeprovider.DefaultTimeProvider()
-		return !timeProvider.IsExpired(*c.ExpiryTime)
-	}
-
-	if c.HyphenAPIKey != nil {
-		return true
-	}
-
-	return false
 }
 
 func (c *Config) IsMonorepoProject() bool {

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"dario.cat/mergo"
+	"github.com/Hyphen/cli/internal/timeprovider"
 	"github.com/Hyphen/cli/pkg/errors"
 	"github.com/Hyphen/cli/pkg/fsutil"
 )
@@ -34,6 +35,29 @@ type Config struct {
 	IsMonorepo         *bool       `json:"is_monorepo,omitempty"`
 	Project            *Project    `json:"project,omitempty"`
 	Database           interface{} `json:"database,omitempty"`
+}
+
+func IsAuthenticated() (bool, error) {
+	config, err := RestoreConfig()
+	if err != nil {
+		return false, err
+	}
+
+	return config.IsAuthenticated(), nil
+}
+
+func (c *Config) IsAuthenticated() bool {
+	if c.ExpiryTime != nil {
+		// validate it's not expired
+		timeProvider := timeprovider.DefaultTimeProvider()
+		return !timeProvider.IsExpired(*c.ExpiryTime)
+	}
+
+	if c.HyphenAPIKey != nil {
+		return true
+	}
+
+	return false
 }
 
 func (c *Config) IsMonorepoProject() bool {

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Hyphen/cli/internal/config"
+	"github.com/Hyphen/cli/internal/timeprovider"
 	"github.com/Hyphen/cli/pkg/apiconf"
 	"github.com/Hyphen/cli/pkg/errors"
 )
@@ -41,16 +42,6 @@ type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-type TimeProvider interface {
-	Now() time.Time
-}
-
-type RealTimeProvider struct{}
-
-func (rtp *RealTimeProvider) Now() time.Time {
-	return time.Now()
-}
-
 type BrowserOpener func(string) error
 
 type OAuthServicer interface {
@@ -66,15 +57,15 @@ type OAuthService struct {
 	baseUrl       string
 	clientID      string
 	httpClient    HTTPClient
-	timeProvider  TimeProvider
+	timeProvider  timeprovider.TimeProvider
 	browserOpener BrowserOpener
 }
 
 func DefaultOAuthService() *OAuthService {
-	return NewOAuthService(&http.Client{}, &RealTimeProvider{}, openBrowser)
+	return NewOAuthService(&http.Client{}, timeprovider.DefaultTimeProvider(), openBrowser)
 }
 
-func NewOAuthService(httpClient HTTPClient, timeProvider TimeProvider, browserOpener BrowserOpener) *OAuthService {
+func NewOAuthService(httpClient HTTPClient, timeProvider timeprovider.TimeProvider, browserOpener BrowserOpener) *OAuthService {
 	baseUrl := apiconf.GetBaseAuthUrl()
 	clientID := apiconf.GetAuthClientID()
 

--- a/internal/oauth/oauth_test.go
+++ b/internal/oauth/oauth_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Hyphen/cli/internal/timeprovider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -37,13 +38,13 @@ func TestDefaultOAuthService(t *testing.T) {
 	service := DefaultOAuthService()
 	assert.NotNil(t, service)
 	assert.IsType(t, &http.Client{}, service.httpClient)
-	assert.IsType(t, &RealTimeProvider{}, service.timeProvider)
+	assert.IsType(t, &timeprovider.RealTimeProvider{}, service.timeProvider)
 	assert.NotNil(t, service.browserOpener)
 }
 
 func TestNewOAuthService(t *testing.T) {
 	httpClient := &MockHTTPClient{}
-	timeProvider := &MockTimeProvider{}
+	timeProvider := timeprovider.NewMockTimeProvider()
 	browserOpener := func(url string) error { return nil }
 	service := NewOAuthService(httpClient, timeProvider, browserOpener)
 	assert.NotNil(t, service)
@@ -63,7 +64,7 @@ func TestGeneratePKCE(t *testing.T) {
 
 func TestExchangeCodeForToken(t *testing.T) {
 	mockClient := new(MockHTTPClient)
-	mockTime := new(MockTimeProvider)
+	mockTime := timeprovider.NewMockTimeProvider()
 	service := NewOAuthService(mockClient, mockTime, func(url string) error { return nil })
 
 	mockResp := &http.Response{
@@ -92,7 +93,7 @@ func TestExchangeCodeForToken(t *testing.T) {
 }
 
 func TestIsTokenExpired(t *testing.T) {
-	mockTime := new(MockTimeProvider)
+	mockTime := timeprovider.NewMockTimeProvider()
 	service := NewOAuthService(&http.Client{}, mockTime, func(url string) error { return nil })
 
 	mockTime.On("Now").Return(time.Unix(1000000000, 0))
@@ -105,7 +106,7 @@ func TestIsTokenExpired(t *testing.T) {
 
 func TestRefreshToken(t *testing.T) {
 	mockClient := new(MockHTTPClient)
-	mockTime := new(MockTimeProvider)
+	mockTime := timeprovider.NewMockTimeProvider()
 	service := NewOAuthService(mockClient, mockTime, func(url string) error { return nil })
 
 	mockResp := &http.Response{
@@ -135,7 +136,7 @@ func TestRefreshToken(t *testing.T) {
 
 func TestStartOAuthServer(t *testing.T) {
 	mockClient := new(MockHTTPClient)
-	mockTime := new(MockTimeProvider)
+	mockTime := timeprovider.NewMockTimeProvider()
 
 	// Create a channel to signal when the browser opener has been called
 	browserOpenerCalled := make(chan bool, 1)
@@ -233,7 +234,7 @@ func TestGeneratePKCE_Error(t *testing.T) {
 
 func TestExchangeCodeForToken_Error(t *testing.T) {
 	mockClient := new(MockHTTPClient)
-	mockTime := new(MockTimeProvider)
+	mockTime := timeprovider.NewMockTimeProvider()
 	service := NewOAuthService(mockClient, mockTime, func(url string) error { return nil })
 
 	mockResp := &http.Response{
@@ -251,7 +252,7 @@ func TestExchangeCodeForToken_Error(t *testing.T) {
 
 func TestRefreshToken_Error(t *testing.T) {
 	mockClient := new(MockHTTPClient)
-	mockTime := new(MockTimeProvider)
+	mockTime := timeprovider.NewMockTimeProvider()
 	service := NewOAuthService(mockClient, mockTime, func(url string) error { return nil })
 
 	mockResp := &http.Response{

--- a/internal/secret/secret.go
+++ b/internal/secret/secret.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"dario.cat/mergo"
+	"github.com/Hyphen/cli/internal/config"
 	"github.com/Hyphen/cli/internal/secretkey"
 	"github.com/Hyphen/cli/internal/vinz"
 	"github.com/Hyphen/cli/pkg/errors"
@@ -79,7 +80,18 @@ func InitializeSecret(organizationId, projectIdOrAlternateId, secretFile string)
 			return Secret{}, errors.Wrapf(err, "Error writing file: %s", secretFile)
 		}
 	} else {
-		_, err := vs.SaveKey(organizationId, projectIdOrAlternateId, vinz.Key{
+
+		// verify we are authenticated first.
+		config, err := config.RestoreConfig()
+		if err != nil {
+			return Secret{}, errors.Wrap(err, "Failed to load configuration. Please authenticate with `hx auth` and try again")
+		}
+
+		if !config.IsAuthenticated() {
+			return Secret{}, errors.New("Your authentication token has expired. Please run `hx auth` and try again")
+		}
+
+		_, err = vs.SaveKey(organizationId, projectIdOrAlternateId, vinz.Key{
 			SecretKeyId: ms.SecretKeyId,
 			SecretKey:   ms.SecretKey,
 		})

--- a/internal/secret/secret.go
+++ b/internal/secret/secret.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"dario.cat/mergo"
-	"github.com/Hyphen/cli/internal/config"
 	"github.com/Hyphen/cli/internal/secretkey"
 	"github.com/Hyphen/cli/internal/vinz"
 	"github.com/Hyphen/cli/pkg/errors"
@@ -80,17 +79,6 @@ func InitializeSecret(organizationId, projectIdOrAlternateId, secretFile string)
 			return Secret{}, errors.Wrapf(err, "Error writing file: %s", secretFile)
 		}
 	} else {
-
-		// verify we are authenticated first.
-		config, err := config.RestoreConfig()
-		if err != nil {
-			return Secret{}, errors.Wrap(err, "Failed to load configuration. Please authenticate with `hx auth` and try again")
-		}
-
-		if !config.IsAuthenticated() {
-			return Secret{}, errors.New("Your authentication token has expired. Please run `hx auth` and try again")
-		}
-
 		_, err = vs.SaveKey(organizationId, projectIdOrAlternateId, vinz.Key{
 			SecretKeyId: ms.SecretKeyId,
 			SecretKey:   ms.SecretKey,

--- a/internal/timeprovider/time_provider.go
+++ b/internal/timeprovider/time_provider.go
@@ -1,0 +1,25 @@
+package timeprovider
+
+import "time"
+
+type TimeProvider interface {
+	Now() time.Time
+	IsExpired(expiryTime int64) bool
+}
+
+type RealTimeProvider struct{}
+
+func (rtp *RealTimeProvider) Now() time.Time {
+	return time.Now()
+}
+
+func (rtp *RealTimeProvider) IsExpired(expiryTime int64) bool {
+	return rtp.Now().After(time.Unix(expiryTime, 0))
+}
+
+func DefaultTimeProvider() TimeProvider {
+	return &RealTimeProvider{}
+}
+
+// Ensure RealTimeProvider implements TimeProvider
+var _ TimeProvider = (*RealTimeProvider)(nil)

--- a/internal/timeprovider/time_provider_mock.go
+++ b/internal/timeprovider/time_provider_mock.go
@@ -1,0 +1,32 @@
+package timeprovider
+
+import (
+	"time"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// MockTimeProvider is a mock implementation of the TimeProvider interface
+type MockTimeProvider struct {
+	mock.Mock
+}
+
+// Ensure MockTimeProvider implements TimeProvider
+var _ TimeProvider = (*MockTimeProvider)(nil)
+
+// Now mocks the Now method
+func (m *MockTimeProvider) Now() time.Time {
+	args := m.Called()
+	return args.Get(0).(time.Time)
+}
+
+// IsExpired mocks the IsExpired method
+func (m *MockTimeProvider) IsExpired(expiryTime int64) bool {
+	args := m.Called(expiryTime)
+	return args.Bool(0)
+}
+
+// NewMockTimeProvider creates a new instance of MockTimeProvider
+func NewMockTimeProvider() *MockTimeProvider {
+	return &MockTimeProvider{}
+}

--- a/internal/user/service.go
+++ b/internal/user/service.go
@@ -19,6 +19,18 @@ type UserService struct {
 	client  httputil.Client
 }
 
+func ErrorIfNotAuthenticated() error {
+	// Try a simple request to force tokens refresh and validate we can get a response
+	_, err := NewService().GetExecutionContext()
+	if errors.Is(err, errors.ErrUnauthorized) || errors.Is(err, errors.ErrForbidden) {
+		return errors.New("You are not authenticated. Please run `hx auth` and try again")
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func NewService() UserServicer {
 	baseUrl := apiconf.GetBaseApixUrl()
 	return &UserService{

--- a/internal/vinz/service.go
+++ b/internal/vinz/service.go
@@ -79,7 +79,7 @@ func (vs *VinzService) SaveKey(organizationID, projectIdOrAlternateId string, ke
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return Key{}, errors.HandleHTTPError(resp)
 	}
 

--- a/internal/zelda/service_test.go
+++ b/internal/zelda/service_test.go
@@ -131,7 +131,7 @@ func TestErrorHandling(t *testing.T) {
 		expectedErrMsg string
 	}{
 		{"BadRequest", http.StatusBadRequest, "Invalid input", "bad request: Invalid input"},
-		{"Unauthorized", http.StatusUnauthorized, "", "unauthorized: please authenticate with `auth` and try again"},
+		{"Unauthorized", http.StatusUnauthorized, "", "unauthorized: please authenticate with `hx auth` and try again"},
 		{"Forbidden", http.StatusForbidden, "", "forbidden: you don't have permission to perform this action"},
 		{"NotFound", http.StatusNotFound, "", "not found: "},
 		{"Conflict", http.StatusConflict, "Resource already exists", "conflict: Resource already exists"},

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -113,7 +113,7 @@ func HandleHTTPError(resp *http.Response) *Error {
 	case http.StatusBadRequest:
 		return Wrapf(ErrBadRequest, "bad request: %s", errorMessage)
 	case http.StatusUnauthorized:
-		return Wrap(ErrUnauthorized, "unauthorized: please authenticate with `auth` and try again")
+		return Wrap(ErrUnauthorized, "unauthorized: please authenticate with `hx auth` and try again")
 	case http.StatusForbidden:
 		return Wrap(ErrForbidden, "forbidden: you don't have permission to perform this action")
 	case http.StatusNotFound:

--- a/pkg/httputil/client.go
+++ b/pkg/httputil/client.go
@@ -40,7 +40,7 @@ func (hc *HyphenClient) Do(req *http.Request) (*http.Response, error) {
 	} else {
 		token, err := hc.oauthService.GetValidToken()
 		if err != nil {
-			return nil, errors.Wrap(err, "Failed to authenticate. Please authenticate with `auth` and try again.")
+			return nil, errors.Wrap(err, "Failed to authenticate. Please authenticate with `hx auth` and try again.")
 		}
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
@@ -73,7 +73,7 @@ func (hc *HyphenClient) GetWebsocketConnection(websocketUrl string) (*websocket.
 	} else {
 		token, err := hc.oauthService.GetValidToken()
 		if err != nil {
-			return nil, errors.Wrap(err, "Failed to authenticate. Please authenticate with `auth` and try again.")
+			return nil, errors.Wrap(err, "Failed to authenticate. Please authenticate with `hx auth` and try again.")
 		}
 		headers.Set("Authorization", "Bearer "+token)
 	}


### PR DESCRIPTION
The issue is that we don't do a great job of actually verifying the user is authenticated before we attempt to make various API calls. We transparently refresh the token if we can, but if enough time passes and the refresh token is also bad, we tend to give the users fairly useless errors, as seen in the card:

![image](https://github.com/user-attachments/assets/6eab374f-25fd-4879-8b47-0b407eb9d2ab)

My fix here is to actually enforce the user is authenticated at the root level of many commands as a `PersistentPreRunE`, which means it will apply to all sub-commands too and can return an error. Upon returning an error, it will display the message, plus the help for the command.

Most of the commands require the user be authenticated, so the `user.ErrorIfNotAuthenticated()` will attempt to fetch an execution context. Transparently, that will refresh tokens if needed via the existing client wiring we have.

There is also a minor refactor to split out a timeprovider from being inline in the oauth logic, just to clean things up.

ref: https://github.com/Hyphen/hx/issues/195
