### PR TITLE
feat: hx build should output a specific build link, not just the application link

### DIFF
--- a/cmd/build/build.go
+++ b/cmd/build/build.go
@@ -17,15 +17,15 @@ var BuildCmd = &cobra.Command{
 	Use:   "build ",
 	Short: "Run a build and post it to hyphen",
 	Long: `
-The deploy command runs a deployment for a given deployment name.
+The build command runs a build and uploads it to hyphen without deploying.
 
 Usage:
-	hyphen deploy <deployment> [flags]
+	hyphen build [flags]
 
 Examples:
-hyphen deploy deploy-dev
+hyphen build
 
-Use 'hyphen link --help' for more information about available flags.
+Use 'hyphen build --help' for more information about available flags.
 `,
 	Args: cobra.RangeArgs(0, 1),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
@@ -41,7 +41,7 @@ Use 'hyphen link --help' for more information about available flags.
 			return
 		}
 
-		url := hyphenapp.ApplicationLink(build.Organization.ID, build.Project.ID, build.App.ID)
+		url := hyphenapp.ApplicationBuildLink(build.Organization.ID, build.Project.ID, build.App.ID, build.Id)
 
 		printer.Info("Build successful: " + url)
 	},

--- a/internal/hyphenApp/hyphenApp.go
+++ b/internal/hyphenApp/hyphenApp.go
@@ -18,6 +18,10 @@ func ApplicationLink(organizationId, projectAlternateId, appAlternateId string) 
 	return fmt.Sprintf("%s/%s/projects/%s/app/%s", apiconf.GetBaseAppUrl(), organizationId, projectAlternateId, appAlternateId)
 }
 
+func ApplicationBuildLink(organizationId, projectAlternateId, appAlternateId, buildId string) string {
+	return fmt.Sprintf("%s/%s/projects/%s/app/%s/builds#%s", apiconf.GetBaseAppUrl(), organizationId, projectAlternateId, appAlternateId, buildId)
+}
+
 func DeploymentLink(organizationId, deploymentId string) string {
 	return fmt.Sprintf("%s/%s/deploy/%s", apiconf.GetBaseAppUrl(), organizationId, deploymentId)
 }


### PR DESCRIPTION
Also some quick updates to the help text, which was duplicated from deploy.

ref: https://github.com/Hyphen/hx/issues/197