### PR TITLE
Attach artifacts to the release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,10 +27,10 @@ jobs:
             goos: darwin
             goarch: arm64
             arch: macos-arm
-          # - os: windows-latest
-          #   goos: windows
-          #   goarch: amd64
-          #   arch: windows
+          - os: windows-latest
+            goos: windows
+            goarch: amd64
+            arch: windows
 
     steps:
       - name: Set up Go

--- a/.github/workflows/deployment-to-prod.yml
+++ b/.github/workflows/deployment-to-prod.yml
@@ -4,34 +4,16 @@ on:
   release:
     types:
       - published
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to test (without v prefix, e.g., 1.2.3)'
-        required: true
-        type: string
-      tag_name:
-        description: 'Tag name for release upload (e.g., v1.2.3)'
-        required: true
-        type: string
 
 jobs:
   extract-version:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.version }}
-      tag_name: ${{ steps.get_version.outputs.tag_name }}
     steps:
       - name: Extract version without 'v' prefix
         id: get_version
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
-            echo "tag_name=${{ inputs.tag_name }}" >> $GITHUB_OUTPUT
-          else
-            echo "version=$(echo ${{ github.ref_name }} | sed 's/^v//')" >> $GITHUB_OUTPUT
-            echo "tag_name=${{ github.ref_name }}" >> $GITHUB_OUTPUT
-          fi
+        run: echo "version=$(echo ${{ github.ref_name }} | sed 's/^v//')" >> $GITHUB_OUTPUT
 
   build:
     needs: extract-version
@@ -71,31 +53,30 @@ jobs:
           tar czf "../hyphen-${VERSION}-darwin-arm64.tar.gz" "hyphen-${VERSION}-macos-arm"
           cd ..
 
-          # # Windows x86_64
-          # cd "hyphen-${VERSION}-windows"
-          # zip "../hyphen-${VERSION}-windows-x86_64.zip" "hyphen-${VERSION}-windows.exe"
-          # cd ..
+          # Windows x86_64
+          cd "hyphen-${VERSION}-windows"
+          zip "../hyphen-${VERSION}-windows-x86_64.zip" "hyphen-${VERSION}-windows.exe"
+          cd ..
 
           # List created archives
-          ls -lh *.tar.gz
+          ls -lh *.tar.gz *.zip
 
       - name: Attach artifacts to release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ needs.extract-version.outputs.version }}"
-          TAG_NAME="${{ needs.extract-version.outputs.tag_name }}"
-          gh release upload "$TAG_NAME" \
+          gh release upload ${{ github.ref_name }} \
             "hyphen-${VERSION}-linux-x86_64.tar.gz" \
             "hyphen-${VERSION}-darwin-x86_64.tar.gz" \
             "hyphen-${VERSION}-darwin-arm64.tar.gz" \
+            "hyphen-${VERSION}-windows-x86_64.zip" \
             --repo ${{ github.repository }}
-            # "hyphen-${VERSION}-windows-x86_64.zip" \
 
-  # upload:
-  #   needs: [extract-version, build]
-  #   uses: ./.github/workflows/upload-package-to-r2.yml
-  #   with:
-  #     version: ${{ needs.extract-version.outputs.version }}
-  #     package_name: hyphen-cli
-  #   secrets: inherit
+  upload:
+    needs: [extract-version, build]
+    uses: ./.github/workflows/upload-package-to-r2.yml
+    with:
+      version: ${{ needs.extract-version.outputs.version }}
+      package_name: hyphen-cli
+    secrets: inherit


### PR DESCRIPTION
I use [mise](https://mise.jdx.dev/) and want to be able to use the hyphen CLI through mise. For now, I made a vfox plugin (at https://github.com/half-ogre/vfox-hyphen), but would rather submit a PR to the mise registry with it using aqua/ubi as they discourage using asdf/vfox for new tools. That requires binaries being available on the GitHub releases. So, this PR modifies the prod deploy to attach the binaries to the release.

I tested this by commenting out the R2 and Windows parts in my fork. You can see the run at https://github.com/half-ogre/hx/actions/runs/18137353999 and the release with the artifacts attached at https://github.com/half-ogre/hx/releases/tag/untagged-e86cb130d7b2603c18a0.

If you don't want to take this, all good; closing it won't hurt my feelings!

(If you do take this, it won't cover attaching the binaries to the existing releases, but I could push up another workflow to do just that via workflow dispatch.)