### PR TITLE
Add Docker Hub integration support

### DIFF
--- a/pkg/dockerutil/dockerutil.go
+++ b/pkg/dockerutil/dockerutil.go
@@ -112,8 +112,8 @@ func Build(dockerFilePath, name, tag string, verbose bool) (string, string, erro
 func Push(nameTag, registryUrl string) (string, error) {
 	var finalImageTag string
 
-	if strings.Contains(registryUrl, ".dkr.ecr.") {
-		// AWS: change : to - and use : as separator
+	if strings.Contains(registryUrl, ".dkr.ecr.") || strings.Contains(registryUrl, "index.docker.io") {
+		// AWS/Docker Hub: change : to - and use : as separator
 		finalImageTag = registryUrl + ":" + strings.ReplaceAll(nameTag, ":", "-")
 	} else {
 		// GCP/Azure: current behavior


### PR DESCRIPTION
We pre-create a repository for all images for a project, so this logic matches AWS so that our final container name matches `index.docker.io/orgname/repositoryname:appname-gitsha`.