### PR TITLE
`hx env run` fails with API key

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -31,7 +31,7 @@ The authentication process supports two methods:
 - API Key Login: If you prefer or are required to use an API key, you can authenticate by providing the key either via an environment variable, an inline flag, or interactively via a prompt.
 
 Examples:
-	hyhen auth
+	hyphen auth
 	hyphen auth --use-api-key # This will read check for HYPHEN_API_KEY in the environment and prompt if not found
 	hyphen auth --set-api-key YOURKEY1234
 	`,

--- a/internal/user/service.go
+++ b/internal/user/service.go
@@ -29,6 +29,10 @@ func ErrorIfNotAuthenticated() error {
 		return err
 	}
 
+	if mc.HyphenAPIKey != nil {
+		return nil
+	}
+
 	if mc.HyphenAccessToken != nil {
 		if mc.ExpiryTime != nil && *mc.ExpiryTime > time.Now().Unix() {
 			return nil


### PR DESCRIPTION
The logic which verifies whether you're logged in demands an access token, when an API key should be sufficient.

Also, noticed a typo in the help docs for `hx auth`.