### PR TITLE
Set up `~/.hx` manually with values from environment variables

### DIFF
--- a/cmd/initapp/hyphen-entrypoint.sh
+++ b/cmd/initapp/hyphen-entrypoint.sh
@@ -1,27 +1,30 @@
 #!/bin/sh
 
-if ! command -v "wget" >/dev/null; then
-    echo "Missing command 'wget'. Please install wget into the Docker container." 1>&2
-    exit 1
-fi
+verify_command() {
+    if ! command -v $1 >/dev/null; then
+        echo "Missing command '$1'. Please install $1 into the Docker container." 1>&2
+        exit 1
+    fi
+}
 
-if ! command -v "sed" >/dev/null; then
-    echo "Missing command 'sed'. Please install sed into the Docker container." 1>&2
-    exit 1
-fi
+verify_command "wget"
+verify_command "sed"
+
+verify_environment() {
+    if ! printenv $1 >/dev/null; then
+        echo "Missing environment variable: $1" 1>&2
+        exit 1
+    fi
+}
+
+verify_environment "HYPHEN_API_KEY"
+verify_environment "HYPHEN_APP_ENVIRONMENT"
+verify_environment "HYPHEN_APP_ID"
+verify_environment "HYPHEN_PROJECT_ID"
+verify_environment "HYPHEN_ORGANIZATION_ID"
 
 if [ $# -eq 0 ]; then
     echo "Missing execution command line. Did you forget a CMD in your Dockerfile?" 1>&2
-    exit 1
-fi
-
-if [ -z "${HYPHEN_API_KEY}" ]; then
-    echo "Missing environment variable: HYPHEN_API_KEY" 1>&2
-    exit 1
-fi
-
-if [ -z "${HYPHEN_APP_ENVIRONMENT}" ]; then
-    echo "Missing environment variable: HYPHEN_APP_ENVIRONMENT" 1>&2
     exit 1
 fi
 
@@ -50,12 +53,14 @@ if ! [ -f ".hyphen/hx" ]; then
     chmod +x ".hyphen/hx"
 fi
 
-echo ">>> Logging into Hyphen..."
+echo ">>> Creating ~/.hx ..."
 
-./.hyphen/hx auth --use-api-key
-if [ $? -ne 0 ]; then
-    exit 1
-fi
+echo "{"                                                      > ~/.hx
+echo "  \"hyphen_api_key\": \"${HYPHEN_API_KEY}\"",          >> ~/.hx
+echo "  \"organization_id\": \"${HYPHEN_ORGANIZATION_ID}\"", >> ~/.hx
+echo "  \"project_id\": \"${HYPHEN_PROJECT_ID}\"",           >> ~/.hx
+echo "  \"app_id\": \"${HYPHEN_APP_ID}\""                    >> ~/.hx
+echo "}"                                                     >> ~/.hx
 
 echo ">>> Pulling environment variables..."
 


### PR DESCRIPTION
Rather than depending on making updates for `-app` (which, as discussed in today's standup, has some problems related to confusion of command line switches vs. configuration file values), it seemed like the easiest thing to do would be to just hand-create the `~/.hx` file in advance of needing any changes to `hx` itself. This can take advantage of Matthew's deployment updates which will be injecting all the environment variables that we use.

This removes the need to embed your local `.hx` file into the container. This also saves a round-trip of `hx auth` which is doing HTTP round trips to put information into `~/.hx` that is unnecessary for the execution, since we have all the important values at hand.

Dockerfile:

```dockerfile
FROM alpine

WORKDIR /app

COPY hyphen-entrypoint.sh .

ENTRYPOINT ["./hyphen-entrypoint.sh"]
CMD ["env"]
```

Run:

```
Attaching to testing-1
testing-1  | >>> Creating ~/.hx ...
testing-1  | >>> Pulling environment variables...
testing-1  | Pulled environments:
testing-1  |   - development -> .env.development
testing-1  | >>> Running...
testing-1  | HOSTNAME=ecad1ccdaa5b
testing-1  | SHLVL=1
testing-1  | HOME=/root
testing-1  | HYPHEN_ORGANIZATION_ID=org_68bf2631c6dee3e2ad8e9248
testing-1  | HYPHEN_DEV=true
testing-1  | PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
testing-1  | HYPHEN_PROJECT_ID=proj_68dac8d5647c1f112385d6f9
testing-1  | HYPHEN_APP_ID=app_68dac98c647c1f112385d704
testing-1  | HYPHEN_API_KEY=<...>
testing-1  | HYPHEN_APP_ENVIRONMENT=development
testing-1  | PWD=/app
testing-1  | FOO=development
testing-1 exited with code 0
```

The `FOO=development` env var comes from the `.env.development` file.