### PR TITLE
Add 'hx entrypoint', and make sure the entrypoint script pulls the default environment

### DIFF
--- a/cmd/entrypoint/entrypoint.go
+++ b/cmd/entrypoint/entrypoint.go
@@ -1,0 +1,65 @@
+package entrypoint
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/Hyphen/cli/pkg/cprint"
+	"github.com/Hyphen/cli/pkg/flags"
+	"github.com/spf13/cobra"
+)
+
+//go:embed hyphen-entrypoint.sh
+var hyphenEntrypoint string
+
+var (
+	forceFlag bool
+	printer   *cprint.CPrinter
+)
+
+var EntrypointCmd = &cobra.Command{
+	Use:   "entrypoint",
+	Short: "Copy hyphen-entrypoint.sh to the current folder",
+	Long: `
+hyphen-entrypoint.sh is a Linux shell script intended to be used in Docker container
+environments. On startup, it will set up your container environment variables based
+on the deployment environment you have selected.
+
+This command will place a copy of the current hyphen-entrypoint.sh file into the
+current folder.
+`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		printer = cprint.NewCPrinter(flags.VerboseFlag)
+		if err := CreateEntrypoint(forceFlag); err != nil {
+			printer.Error(cmd, err)
+		}
+	},
+}
+
+func init() {
+	EntrypointCmd.Flags().BoolVar(&forceFlag, "force", false, "Force overwrite of hyphen-entrypoint.sh if it already exists")
+}
+
+func CreateEntrypoint(force bool) error {
+	if !force {
+		if _, err := os.Stat("hyphen-entrypoint.sh"); err == nil {
+			return errors.New("hyphen-entrypoint.sh already exists; use --force to overwrite")
+		}
+	}
+
+	file, err := os.OpenFile("hyphen-entrypoint.sh", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return fmt.Errorf("error creating hyphen-entrypoint.sh: %w", err)
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(hyphenEntrypoint)
+	if err != nil {
+		return fmt.Errorf("error writing to hyphen-entrypoint.sh: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/entrypoint/hyphen-entrypoint.sh
+++ b/cmd/entrypoint/hyphen-entrypoint.sh
@@ -64,6 +64,11 @@ echo "}"                                                     >> ~/.hx
 
 echo ">>> Pulling environment variables..."
 
+./.hyphen/hx pull default --force --yes
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+
 ./.hyphen/hx pull "${HYPHEN_APP_ENVIRONMENT}" --force --yes
 if [ $? -ne 0 ]; then
     exit 1

--- a/cmd/initapp/initapp.go
+++ b/cmd/initapp/initapp.go
@@ -1,12 +1,12 @@
 package initapp
 
 import (
-	_ "embed"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/Hyphen/cli/cmd/entrypoint"
 	"github.com/Hyphen/cli/internal/app"
 	"github.com/Hyphen/cli/internal/config"
 	"github.com/Hyphen/cli/internal/database"
@@ -25,9 +25,6 @@ import (
 
 var appIDFlag string
 var printer *cprint.CPrinter
-
-//go:embed hyphen-entrypoint.sh
-var hyphenEntrypoint string
 
 var InitCmd = &cobra.Command{
 	Use:   "init-app <app name>",
@@ -202,7 +199,7 @@ func RunInitApp(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	err = CreateEntrypoint(cmd)
+	err = entrypoint.CreateEntrypoint(true)
 	if err != nil {
 		return
 	}
@@ -292,23 +289,6 @@ func CreateAndPushEmptyEnvFile(cmd *cobra.Command, envService *env.EnvService, c
 
 	if err := db.UpsertSecret(secretKey, newEnvDecrypted, version); err != nil {
 		return fmt.Errorf("failed to save local environment: %w", err)
-	}
-
-	return nil
-}
-
-func CreateEntrypoint(cmd *cobra.Command) error {
-	file, err := os.OpenFile("hyphen-entrypoint.sh", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
-	if err != nil {
-		printer.Error(cmd, fmt.Errorf("error creating hyphen-entrypoint.sh: %w", err))
-		return err
-	}
-	defer file.Close()
-
-	_, err = file.WriteString(hyphenEntrypoint)
-	if err != nil {
-		printer.Error(cmd, fmt.Errorf("error writing to hyphen-entrypoint.sh: %w", err))
-		return err
 	}
 
 	return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Hyphen/cli/cmd/build"
 	"github.com/Hyphen/cli/cmd/code"
 	"github.com/Hyphen/cli/cmd/deploy"
+	"github.com/Hyphen/cli/cmd/entrypoint"
 	"github.com/Hyphen/cli/cmd/env"
 	"github.com/Hyphen/cli/cmd/env/pull"
 	"github.com/Hyphen/cli/cmd/env/push"
@@ -48,6 +49,7 @@ func init() {
 	rootCmd.AddCommand(project.ProjectCmd)
 	rootCmd.AddCommand(env.EnvCmd)
 	rootCmd.AddCommand(initproject.InitProjectCmd)
+	rootCmd.AddCommand(entrypoint.EntrypointCmd)
 
 	// Override the default completion command with a hidden no-op command
 	rootCmd.AddCommand(&cobra.Command{


### PR DESCRIPTION
This creates a new `entrypoint` command (with `--force` switch) to drop the `hyphen-entrypoint.sh` into the current folder.

The `hyphen-entrypoint.sh` is also updated to ensure we pull the default environment in addition to the requested environment, so we can merge the two sets of environment variables.