### PR TITLE
Fix nil pointer panic in GenerateDocker

### DIFF
--- a/cmd/build/build.go
+++ b/cmd/build/build.go
@@ -34,7 +34,7 @@ Use 'hyphen build --help' for more information about available flags.
 	RunE: func(cmd *cobra.Command, args []string) error {
 		printer = cprint.NewCPrinter(flags.VerboseFlag)
 		service := build.NewService()
-		build, err := service.RunBuild(printer, "", flags.VerboseFlag, flags.DockerfileFlag)
+		build, err := service.RunBuild(cmd, printer, "", flags.VerboseFlag, flags.DockerfileFlag)
 
 		if err != nil {
 			return err

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -103,7 +103,7 @@ Use 'hyphen deploy --help' for more information about available flags.
 			firstApp := selectedDeployment.Apps[0]
 
 			service := build.NewService()
-			result, err := service.RunBuild(printer, firstApp.DeploymentSettings.ProjectEnvironment.ID, flags.VerboseFlag, flags.DockerfileFlag)
+			result, err := service.RunBuild(cmd, printer, firstApp.DeploymentSettings.ProjectEnvironment.ID, flags.VerboseFlag, flags.DockerfileFlag)
 			if err != nil {
 				return err
 			}

--- a/internal/build/service.go
+++ b/internal/build/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Hyphen/cli/pkg/errors"
 	"github.com/Hyphen/cli/pkg/gitutil"
 	"github.com/Hyphen/cli/pkg/httputil"
+	"github.com/spf13/cobra"
 )
 
 type BuildService struct {
@@ -133,7 +134,7 @@ func (bs *BuildService) FindRegistryConnection(organizationId, projectId string)
 
 }
 
-func (bs *BuildService) RunBuild(printer *cprint.CPrinter, environmentId string, verbose bool, dockerfilePath string) (*models.Build, error) {
+func (bs *BuildService) RunBuild(cmd *cobra.Command, printer *cprint.CPrinter, environmentId string, verbose bool, dockerfilePath string) (*models.Build, error) {
 	// grab the manifest to get app details
 	config, err := config.RestoreConfig()
 	if err != nil {
@@ -163,7 +164,7 @@ func (bs *BuildService) RunBuild(printer *cprint.CPrinter, environmentId string,
 		dockerfileDir, err := dockerutil.FindDockerFile()
 		if err != nil || dockerfileDir == "" {
 			coder := code.NewService()
-			err = coder.GenerateDocker(printer, nil)
+			err = coder.GenerateDocker(printer, cmd)
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate docker file: %w", err)
 			}


### PR DESCRIPTION
This fixes #234 in which there are several cases where we were dereferencing nil when printing to the console in GenerateDocker, leading to a panic.