### PR TITLE
feat: add --output json to build and deploy

### DIFF
--- a/cmd/build/build.go
+++ b/cmd/build/build.go
@@ -1,6 +1,9 @@
 package build
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/Hyphen/cli/internal/build"
 	hyphenapp "github.com/Hyphen/cli/internal/hyphenApp"
 	"github.com/Hyphen/cli/internal/user"
@@ -10,7 +13,8 @@ import (
 )
 
 var (
-	printer *cprint.CPrinter
+	printer          *cprint.CPrinter
+	outputFormatFlag string
 )
 
 var BuildCmd = &cobra.Command{
@@ -33,22 +37,64 @@ Use 'hyphen build --help' for more information about available flags.
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		printer = cprint.NewCPrinter(flags.VerboseFlag)
-		service := build.NewService()
-		build, err := service.RunBuild(cmd, printer, flags.EnvironmentFlag, flags.VerboseFlag, flags.DockerfileFlag, flags.PreviewNameFlag)
+		printer.SetFormat(outputFormatFlag)
 
-		if err != nil {
-			return err
+		result, runErr := runBuild(cmd)
+		if runErr != nil {
+			if printer.IsJSON() {
+				emitFailure(printer, map[string]any{}, runErr)
+				// Silence cobra's error/usage output so it doesn't
+				// pollute stdout after we've emitted the JSON
+				// payload — the error is already surfaced in the
+				// payload's "reason" field.
+				cmd.SilenceErrors = true
+				cmd.SilenceUsage = true
+			}
+			return runErr
 		}
 
-		url := hyphenapp.ApplicationBuildLink(build.Organization.ID, build.Project.ID, build.App.ID, build.Id)
-
-		printer.Info("Build successful: " + url)
-		return nil
+		return printer.Emit(result)
 	},
+}
+
+// emitFailure writes the failure JSON payload to stdout and falls back to
+// stderr if Emit itself fails. Ensures we never silently drop the error in
+// JSON mode.
+func emitFailure(p *cprint.CPrinter, partial map[string]any, err error) {
+	partial["status"] = "failed"
+	partial["reason"] = err.Error()
+	if emitErr := p.Emit(partial); emitErr != nil {
+		fmt.Fprintf(os.Stderr, "failed to emit JSON output: %v\n", emitErr)
+	}
+}
+
+// runBuild performs the build and returns the result fields to emit, or an
+// error. Keeping the body here (rather than inline in RunE) lets the RunE
+// wrapper uniformly translate any error into a JSON failure payload when
+// --output=json is set.
+func runBuild(cmd *cobra.Command) (map[string]any, error) {
+	service := build.NewService()
+	result, err := service.RunBuild(cmd, printer, flags.EnvironmentFlag, flags.VerboseFlag, flags.DockerfileFlag, flags.PreviewNameFlag)
+	if err != nil {
+		return nil, err
+	}
+
+	url := hyphenapp.ApplicationBuildLink(result.Organization.ID, result.Project.ID, result.App.ID, result.Id)
+	printer.Info("Build successful: " + url)
+
+	return map[string]any{
+		"status":         "succeeded",
+		"buildId":        result.Id,
+		"appId":          result.App.ID,
+		"projectId":      result.Project.ID,
+		"organizationId": result.Organization.ID,
+		"buildUrl":       url,
+	}, nil
 }
 
 func init() {
 	BuildCmd.Flags().StringVarP(&flags.DockerfileFlag, "dockerfile", "f", "", "Path to Dockerfile (e.g., ./Dockerfile or ./docker/Dockerfile.prod)")
 	BuildCmd.Flags().StringVarP(&flags.EnvironmentFlag, "env", "e", "", "Environment ID for the build")
 	BuildCmd.Flags().StringVarP(&flags.PreviewNameFlag, "preview", "r", "", "Preview name to associate with this build")
+	BuildCmd.Flags().StringVar(&outputFormatFlag, "output", "", "Output format. Set to \"json\" to emit a JSON object with status, buildId, appId, projectId, organizationId, buildUrl, reason (on failure), and a messages array.")
 }

--- a/cmd/build/build_test.go
+++ b/cmd/build/build_test.go
@@ -12,4 +12,16 @@ func TestBuildCmd(t *testing.T) {
 
 		assert.NotNil(t, flag, "build command should have an --env flag to specify the environment")
 	})
+
+	t.Run("has_an_output_flag", func(t *testing.T) {
+		flag := BuildCmd.Flags().Lookup("output")
+
+		assert.NotNil(t, flag, "build command should have an --output flag")
+	})
+
+	t.Run("defaults_the_output_flag_to_empty_string", func(t *testing.T) {
+		flag := BuildCmd.Flags().Lookup("output")
+
+		assert.Equal(t, "", flag.DefValue)
+	})
 }

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -66,7 +66,13 @@ Use 'hyphen deploy --help' for more information about available flags.
 				if result == nil {
 					result = map[string]any{}
 				}
-				result["status"] = "failed"
+				// Preserve a real terminal status (e.g. "canceled") if
+				// runDeployBody set one before failing; otherwise mark
+				// the run as failed so JSON consumers see a consistent
+				// non-empty status.
+				if _, ok := result["status"]; !ok {
+					result["status"] = "failed"
+				}
 				result["reason"] = runErr.Error()
 				if emitErr := printer.Emit(result); emitErr != nil {
 					fmt.Fprintf(os.Stderr, "failed to emit JSON output: %v\n", emitErr)
@@ -77,25 +83,18 @@ Use 'hyphen deploy --help' for more information about available flags.
 				// payload's "reason" field.
 				cmd.SilenceErrors = true
 				cmd.SilenceUsage = true
+			} else {
+				// Human mode already streamed the failure context to
+				// stdout, so silence cobra's redundant "Error: ..."
+				// line — but still return the error to drive a
+				// non-zero exit code.
+				cmd.SilenceErrors = true
+				cmd.SilenceUsage = true
 			}
 			return runErr
 		}
 
-		if err := printer.Emit(result); err != nil {
-			return err
-		}
-
-		// A non-succeeded deployment is a failure regardless of output
-		// format: CI and scripts should see a non-zero exit. In human
-		// mode the streaming output already showed the final status,
-		// so silence cobra's redundant "Error: ..." line.
-		if result["status"] != "succeeded" {
-			cmd.SilenceErrors = true
-			cmd.SilenceUsage = true
-			return fmt.Errorf("deployment ended with status %q", result["status"])
-		}
-
-		return nil
+		return printer.Emit(result)
 	},
 }
 
@@ -326,13 +325,25 @@ func runDeployBody(cmd *cobra.Command, args []string) (map[string]any, error) {
 	result["deploymentUrl"] = appUrl
 
 	var finalStatus string
+	var streamErr error
 	if shouldUseTUI() {
-		finalStatus = runWithTUI(orgId, selectedDeployment.ID, run, appUrl, service)
+		finalStatus, streamErr = runWithTUI(orgId, selectedDeployment.ID, run, appUrl, service)
 	} else {
-		finalStatus = runWithoutTUI(orgId, selectedDeployment.ID, run, appUrl, service)
+		finalStatus, streamErr = runWithoutTUI(orgId, selectedDeployment.ID, run, appUrl, service)
 	}
 
-	result["status"] = finalStatus
+	if finalStatus != "" {
+		result["status"] = finalStatus
+	}
+
+	if streamErr != nil {
+		return result, fmt.Errorf("failed to monitor deployment: %w", streamErr)
+	}
+
+	if finalStatus != "succeeded" {
+		return result, fmt.Errorf("deployment ended with status %q", finalStatus)
+	}
+
 	return result, nil
 }
 
@@ -433,7 +444,7 @@ func streamDeployEvents(orgId string, runID string, callbacks deployCallbacks) e
 	return nil
 }
 
-func runWithTUI(orgId, deploymentId string, run *models.DeploymentRun, appUrl string, service *Deployment.DeploymentService) string {
+func runWithTUI(orgId, deploymentId string, run *models.DeploymentRun, appUrl string, service *Deployment.DeploymentService) (string, error) {
 	statusModel := Deployment.StatusModel{
 		OrganizationId: orgId,
 		DeploymentId:   deploymentId,
@@ -447,6 +458,7 @@ func runWithTUI(orgId, deploymentId string, run *models.DeploymentRun, appUrl st
 	statusDisplay := tea.NewProgram(statusModel)
 
 	var finalStatus string
+	var streamErr error
 	var wg sync.WaitGroup
 	wg.Add(1)
 
@@ -478,16 +490,18 @@ func runWithTUI(orgId, deploymentId string, run *models.DeploymentRun, appUrl st
 		})
 
 		if err != nil {
+			streamErr = err
 			statusDisplay.Send(Deployment.ErrorMessage{Error: err})
+			statusDisplay.Quit()
 		}
 	}()
 
 	statusDisplay.Run()
 	wg.Wait()
-	return finalStatus
+	return finalStatus, streamErr
 }
 
-func runWithoutTUI(orgId string, deploymentId string, run *models.DeploymentRun, appUrl string, service *Deployment.DeploymentService) string {
+func runWithoutTUI(orgId string, deploymentId string, run *models.DeploymentRun, appUrl string, service *Deployment.DeploymentService) (string, error) {
 	printer.Print(fmt.Sprintf("Deployment URL: %s", appUrl))
 	printer.Print("Monitoring deployment progress...")
 
@@ -518,8 +532,9 @@ func runWithoutTUI(orgId string, deploymentId string, run *models.DeploymentRun,
 
 	if err != nil {
 		printer.Print(fmt.Sprintf("Error: %v", err))
+		return finalStatus, err
 	}
-	return finalStatus
+	return finalStatus, nil
 }
 
 func printPipelineUpdates(pipelineData map[string]any) {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -24,11 +24,12 @@ import (
 )
 
 var (
-	noBuild     bool
-	envFlag     string
-	projectFlag string
-	appsFlag    string
-	printer     *cprint.CPrinter
+	noBuild          bool
+	envFlag          string
+	projectFlag      string
+	appsFlag         string
+	outputFormatFlag string
+	printer          *cprint.CPrinter
 )
 
 var DeployCmd = &cobra.Command{
@@ -55,227 +56,290 @@ Use 'hyphen deploy --help' for more information about available flags.
 		return user.ErrorIfNotAuthenticated()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		orgId, err := flags.GetOrganizationID()
-		if err != nil {
+		printer = cprint.NewCPrinter(flags.VerboseFlag)
+		printer.SetFormat(outputFormatFlag)
+
+		result, runErr := runDeployBody(cmd, args)
+
+		if runErr != nil {
+			if printer.IsJSON() {
+				if result == nil {
+					result = map[string]any{}
+				}
+				result["status"] = "failed"
+				result["reason"] = runErr.Error()
+				if emitErr := printer.Emit(result); emitErr != nil {
+					fmt.Fprintf(os.Stderr, "failed to emit JSON output: %v\n", emitErr)
+				}
+				// Silence cobra's error/usage output so it doesn't
+				// pollute stdout after we've emitted the JSON
+				// payload — the error is already surfaced in the
+				// payload's "reason" field.
+				cmd.SilenceErrors = true
+				cmd.SilenceUsage = true
+			}
+			return runErr
+		}
+
+		if err := printer.Emit(result); err != nil {
 			return err
 		}
 
-		printer = cprint.NewCPrinter(flags.VerboseFlag)
-
-		service := Deployment.NewService()
-
-		var selectedDeployment models.Deployment
-
-		if len(args) == 0 {
-			cfg, err := config.RestoreLocalConfig()
-			if err != nil {
-				return fmt.Errorf("failed to restore config: %w", err)
-			}
-
-			projectId := projectFlag
-			if cfg.ProjectId != nil {
-				projectId = *cfg.ProjectId
-			}
-			if projectId == "" {
-				return fmt.Errorf("project id not found in config")
-			}
-
-			var envId string
-			if envFlag != "" {
-				envId = envFlag
-			} else {
-				envService := env.NewService()
-				devEnv, devEnvErr := envService.GetDevelopmentEnvironment(orgId, projectId)
-				if errors.Is(devEnvErr, errors.ErrNotFound) {
-					return fmt.Errorf("no development environment found for this project")
-				}
-				if devEnvErr != nil {
-					return fmt.Errorf("failed to get development environment: %w", devEnvErr)
-				}
-				envId = devEnv.ID
-			}
-
-			projectService := projects.NewService(orgId)
-			deployment, deploymentErr := projectService.GetEnvironmentDeployment(projectId, envId)
-			if deploymentErr != nil && !errors.Is(deploymentErr, errors.ErrNotFound) {
-				return fmt.Errorf("failed to get deployment for environment: %w", deploymentErr)
-			}
-
-			if errors.Is(deploymentErr, errors.ErrNotFound) || deployment.ID == "" {
-				project, err := projectService.GetProject(projectId)
-				if err != nil {
-					return fmt.Errorf("failed to get project: %w", err)
-				}
-				if cfg.AppId == nil {
-					return fmt.Errorf("app id not found in config")
-				}
-
-				name := deploymentNamePart(project.AlternateID, 25)
-
-				newDeployment, err := service.CreateEnvironmentDeployment(orgId, projectId, envId, *cfg.AppId, name, name, "")
-				if err != nil {
-					return fmt.Errorf("failed to create deployment: %w", err)
-				}
-				selectedDeployment = *newDeployment
-			} else {
-				selectedDeployment = deployment
-			}
-		} else {
-			deployment, err := service.GetDeployment(orgId, args[0])
-			if err != nil {
-				return fmt.Errorf("failed to get deployment: %w", err)
-			}
-
-			selectedDeployment = *deployment
-		}
-		if !selectedDeployment.IsReady {
-			printer.Print("❌ There are issues blocking this deployment from being run.")
-			for _, issue := range selectedDeployment.ReadinessIssues {
-				if issue.Cloud != "" {
-					printer.Print(fmt.Sprintf("  • %s (%s)", issue.Error, issue.Cloud))
-				} else {
-					printer.Print(fmt.Sprintf("  • %s", issue.Error))
-				}
-			}
-			return nil
-		}
-
-		// Match preview if preview flag is provided
-		var previewId string
-		if flags.PreviewNameFlag != "" {
-			matchedPreviews := []models.DeploymentPreview{}
-			for _, p := range selectedDeployment.Previews {
-				if p.Name == flags.PreviewNameFlag {
-					// If prefix is provided, also match by hostPrefix
-					if flags.PreviewPrefixFlag != "" {
-						if p.HostPrefix == flags.PreviewPrefixFlag {
-							matchedPreviews = append(matchedPreviews, p)
-						}
-					} else {
-						matchedPreviews = append(matchedPreviews, p)
-					}
-				}
-			}
-
-			if len(matchedPreviews) == 0 {
-				if flags.PreviewPrefixFlag == "" {
-					return fmt.Errorf("no preview found with name '%s', please specify --prefix flag to create a new preview", flags.PreviewNameFlag)
-				}
-				newPreview, err := service.CreatePreview(orgId, selectedDeployment, flags.PreviewNameFlag, flags.PreviewPrefixFlag)
-				if err != nil {
-					return fmt.Errorf("failed to create preview: %w", err)
-				}
-				previewId = newPreview.ID
-			} else if len(matchedPreviews) > 1 {
-				return fmt.Errorf("multiple previews found with name '%s', please specify --prefix flag to disambiguate", flags.PreviewNameFlag)
-			} else {
-				previewId = matchedPreviews[0].ID
-			}
-		}
-
-		appSources := []Deployment.AppSources{}
-
-		if appsFlag != "" {
-			cfg, cfgErr := config.RestoreLocalConfig()
-			if cfgErr != nil && !os.IsNotExist(cfgErr) {
-				return fmt.Errorf("failed to restore config: %w", cfgErr)
-			}
-
-			parsedApps, err := parseAppsFlag(appsFlag)
-			if err != nil {
-				return err
-			}
-
-			for _, pa := range parsedApps {
-				deployApp, err := resolveDeploymentApp(pa.ID, selectedDeployment)
-				if err != nil {
-					return err
-				}
-
-				if noBuild {
-					appSources = append(appSources, Deployment.AppSources{
-						AppId: deployApp.App.ID,
-						Build: "latest",
-					})
-					continue
-				}
-
-				if pa.BuildSpec == "" && matchesHxApp(pa.ID, cfg) {
-					buildSvc := build.NewService()
-					result, err := buildSvc.RunBuild(cmd, printer, selectedDeployment.ProjectEnvironment.ID, flags.VerboseFlag, flags.DockerfileFlag, flags.PreviewNameFlag)
-					if err != nil {
-						return err
-					}
-					appSources = append(appSources, Deployment.AppSources{
-						AppId:   result.App.ID,
-						BuildId: result.Id,
-					})
-				} else {
-					src := Deployment.AppSources{AppId: deployApp.App.ID}
-					switch pa.BuildSpec {
-					case "", "latest":
-						src.Build = "latest"
-					case "lastDeployed":
-						src.Build = "lastDeployed"
-					case "latestPreview":
-						src.Build = "latestPreview"
-					default:
-						if !strings.HasPrefix(pa.BuildSpec, "abld_") {
-							return fmt.Errorf("unknown build type %q: expected \"latest\", \"lastDeployed\", \"latestPreview\", or a build ID starting with \"abld_\"", pa.BuildSpec)
-						}
-						src.BuildId = pa.BuildSpec
-					}
-					appSources = append(appSources, src)
-				}
-			}
-		} else if noBuild {
-			for _, app := range selectedDeployment.Apps {
-				appSources = append(appSources, Deployment.AppSources{
-					AppId: app.App.ID,
-					Build: "latest",
-				})
-			}
-		} else {
-			buildSvc := build.NewService()
-			result, err := buildSvc.RunBuild(cmd, printer, selectedDeployment.ProjectEnvironment.ID, flags.VerboseFlag, flags.DockerfileFlag, flags.PreviewNameFlag)
-			if err != nil {
-				return err
-			}
-			for _, app := range selectedDeployment.Apps {
-				if app.App.ID == result.App.ID {
-					appSources = append(appSources, Deployment.AppSources{
-						AppId:   result.App.ID,
-						BuildId: result.Id,
-					})
-				} else {
-					appSources = append(appSources, Deployment.AppSources{
-						AppId: app.App.ID,
-						Build: "latest",
-					})
-				}
-			}
-		}
-
-		printer.Print(fmt.Sprintf("Running %s", selectedDeployment.Name))
-
-		run, err := service.CreateRun(orgId, selectedDeployment.ID, appSources, previewId)
-		if err != nil {
-			return fmt.Errorf("failed to create run: %w", err)
-		}
-
-		appUrl := fmt.Sprintf("%s/%s/deploy/%s/runs/%s", apiconf.GetBaseAppUrl(), orgId, selectedDeployment.ID, run.ID)
-
-		if shouldUseTUI() {
-			runWithTUI(orgId, selectedDeployment.ID, run, appUrl, service)
-		} else {
-			runWithoutTUI(orgId, selectedDeployment.ID, run, appUrl, service)
+		// A non-succeeded deployment is a failure regardless of output
+		// format: CI and scripts should see a non-zero exit. In human
+		// mode the streaming output already showed the final status,
+		// so silence cobra's redundant "Error: ..." line.
+		if result["status"] != "succeeded" {
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+			return fmt.Errorf("deployment ended with status %q", result["status"])
 		}
 
 		return nil
 	},
 }
 
+// runDeployBody performs the deployment and returns a result map suitable
+// for emitting as the --output=json payload. The result is accumulated as
+// the command progresses so that an early error still returns everything
+// known so far (deploymentId, runId, deploymentUrl as available); the outer
+// RunE wrapper tags it with status=failed and reason on error.
+func runDeployBody(cmd *cobra.Command, args []string) (map[string]any, error) {
+	result := map[string]any{}
+
+	orgId, err := flags.GetOrganizationID()
+	if err != nil {
+		return result, err
+	}
+
+	service := Deployment.NewService()
+
+	var selectedDeployment models.Deployment
+
+	if len(args) == 0 {
+		cfg, err := config.RestoreLocalConfig()
+		if err != nil {
+			return result, fmt.Errorf("failed to restore config: %w", err)
+		}
+
+		projectId := projectFlag
+		if cfg.ProjectId != nil {
+			projectId = *cfg.ProjectId
+		}
+		if projectId == "" {
+			return result, fmt.Errorf("project id not found in config")
+		}
+
+		var envId string
+		if envFlag != "" {
+			envId = envFlag
+		} else {
+			envService := env.NewService()
+			devEnv, devEnvErr := envService.GetDevelopmentEnvironment(orgId, projectId)
+			if errors.Is(devEnvErr, errors.ErrNotFound) {
+				return result, fmt.Errorf("no development environment found for this project")
+			}
+			if devEnvErr != nil {
+				return result, fmt.Errorf("failed to get development environment: %w", devEnvErr)
+			}
+			envId = devEnv.ID
+		}
+
+		projectService := projects.NewService(orgId)
+		deployment, deploymentErr := projectService.GetEnvironmentDeployment(projectId, envId)
+		if deploymentErr != nil && !errors.Is(deploymentErr, errors.ErrNotFound) {
+			return result, fmt.Errorf("failed to get deployment for environment: %w", deploymentErr)
+		}
+
+		if errors.Is(deploymentErr, errors.ErrNotFound) || deployment.ID == "" {
+			project, err := projectService.GetProject(projectId)
+			if err != nil {
+				return result, fmt.Errorf("failed to get project: %w", err)
+			}
+			if cfg.AppId == nil {
+				return result, fmt.Errorf("app id not found in config")
+			}
+
+			name := deploymentNamePart(project.AlternateID, 25)
+
+			newDeployment, err := service.CreateEnvironmentDeployment(orgId, projectId, envId, *cfg.AppId, name, name, "")
+			if err != nil {
+				return result, fmt.Errorf("failed to create deployment: %w", err)
+			}
+			selectedDeployment = *newDeployment
+		} else {
+			selectedDeployment = deployment
+		}
+	} else {
+		deployment, err := service.GetDeployment(orgId, args[0])
+		if err != nil {
+			return result, fmt.Errorf("failed to get deployment: %w", err)
+		}
+
+		selectedDeployment = *deployment
+	}
+
+	result["deploymentId"] = selectedDeployment.ID
+
+	if !selectedDeployment.IsReady {
+		printer.Print("❌ There are issues blocking this deployment from being run.")
+		issues := []string{}
+		for _, issue := range selectedDeployment.ReadinessIssues {
+			var line string
+			if issue.Cloud != "" {
+				line = fmt.Sprintf("%s (%s)", issue.Error, issue.Cloud)
+			} else {
+				line = issue.Error
+			}
+			printer.Print("  • " + line)
+			issues = append(issues, line)
+		}
+		return result, fmt.Errorf("deployment not ready: %s", strings.Join(issues, "; "))
+	}
+
+	// Match preview if preview flag is provided
+	var previewId string
+	if flags.PreviewNameFlag != "" {
+		matchedPreviews := []models.DeploymentPreview{}
+		for _, p := range selectedDeployment.Previews {
+			// If prefix is provided, also match by hostPrefix
+			if p.Name == flags.PreviewNameFlag {
+				if flags.PreviewPrefixFlag != "" {
+					if p.HostPrefix == flags.PreviewPrefixFlag {
+						matchedPreviews = append(matchedPreviews, p)
+					}
+				} else {
+					matchedPreviews = append(matchedPreviews, p)
+				}
+			}
+		}
+
+		if len(matchedPreviews) == 0 {
+			if flags.PreviewPrefixFlag == "" {
+				return result, fmt.Errorf("no preview found with name '%s', please specify --prefix flag to create a new preview", flags.PreviewNameFlag)
+			}
+			newPreview, err := service.CreatePreview(orgId, selectedDeployment, flags.PreviewNameFlag, flags.PreviewPrefixFlag)
+			if err != nil {
+				return result, fmt.Errorf("failed to create preview: %w", err)
+			}
+			previewId = newPreview.ID
+		} else if len(matchedPreviews) > 1 {
+			return result, fmt.Errorf("multiple previews found with name '%s', please specify --prefix flag to disambiguate", flags.PreviewNameFlag)
+		} else {
+			previewId = matchedPreviews[0].ID
+		}
+	}
+
+	appSources := []Deployment.AppSources{}
+
+	if appsFlag != "" {
+		cfg, cfgErr := config.RestoreLocalConfig()
+		if cfgErr != nil && !os.IsNotExist(cfgErr) {
+			return result, fmt.Errorf("failed to restore config: %w", cfgErr)
+		}
+
+		parsedApps, err := parseAppsFlag(appsFlag)
+		if err != nil {
+			return result, err
+		}
+
+		for _, pa := range parsedApps {
+			deployApp, err := resolveDeploymentApp(pa.ID, selectedDeployment)
+			if err != nil {
+				return result, err
+			}
+
+			if noBuild {
+				appSources = append(appSources, Deployment.AppSources{
+					AppId: deployApp.App.ID,
+					Build: "latest",
+				})
+				continue
+			}
+
+			if pa.BuildSpec == "" && matchesHxApp(pa.ID, cfg) {
+				buildSvc := build.NewService()
+				buildResult, err := buildSvc.RunBuild(cmd, printer, selectedDeployment.ProjectEnvironment.ID, flags.VerboseFlag, flags.DockerfileFlag, flags.PreviewNameFlag)
+				if err != nil {
+					return result, err
+				}
+				appSources = append(appSources, Deployment.AppSources{
+					AppId:   buildResult.App.ID,
+					BuildId: buildResult.Id,
+				})
+			} else {
+				src := Deployment.AppSources{AppId: deployApp.App.ID}
+				switch pa.BuildSpec {
+				case "", "latest":
+					src.Build = "latest"
+				case "lastDeployed":
+					src.Build = "lastDeployed"
+				case "latestPreview":
+					src.Build = "latestPreview"
+				default:
+					if !strings.HasPrefix(pa.BuildSpec, "abld_") {
+						return result, fmt.Errorf("unknown build type %q: expected \"latest\", \"lastDeployed\", \"latestPreview\", or a build ID starting with \"abld_\"", pa.BuildSpec)
+					}
+					src.BuildId = pa.BuildSpec
+				}
+				appSources = append(appSources, src)
+			}
+		}
+	} else if noBuild {
+		for _, app := range selectedDeployment.Apps {
+			appSources = append(appSources, Deployment.AppSources{
+				AppId: app.App.ID,
+				Build: "latest",
+			})
+		}
+	} else {
+		buildSvc := build.NewService()
+		buildResult, err := buildSvc.RunBuild(cmd, printer, selectedDeployment.ProjectEnvironment.ID, flags.VerboseFlag, flags.DockerfileFlag, flags.PreviewNameFlag)
+		if err != nil {
+			return result, err
+		}
+		for _, app := range selectedDeployment.Apps {
+			if app.App.ID == buildResult.App.ID {
+				appSources = append(appSources, Deployment.AppSources{
+					AppId:   buildResult.App.ID,
+					BuildId: buildResult.Id,
+				})
+			} else {
+				appSources = append(appSources, Deployment.AppSources{
+					AppId: app.App.ID,
+					Build: "latest",
+				})
+			}
+		}
+	}
+
+	printer.Print(fmt.Sprintf("Running %s", selectedDeployment.Name))
+
+	run, err := service.CreateRun(orgId, selectedDeployment.ID, appSources, previewId)
+	if err != nil {
+		return result, fmt.Errorf("failed to create run: %w", err)
+	}
+
+	appUrl := fmt.Sprintf("%s/%s/deploy/%s/runs/%s", apiconf.GetBaseAppUrl(), orgId, selectedDeployment.ID, run.ID)
+
+	result["runId"] = run.ID
+	result["deploymentUrl"] = appUrl
+
+	var finalStatus string
+	if shouldUseTUI() {
+		finalStatus = runWithTUI(orgId, selectedDeployment.ID, run, appUrl, service)
+	} else {
+		finalStatus = runWithoutTUI(orgId, selectedDeployment.ID, run, appUrl, service)
+	}
+
+	result["status"] = finalStatus
+	return result, nil
+}
+
 func shouldUseTUI() bool {
+	if outputFormatFlag == cprint.FormatJSON {
+		return false
+	}
 	return term.IsTerminal(int(os.Stdout.Fd()))
 }
 
@@ -369,7 +433,7 @@ func streamDeployEvents(orgId string, runID string, callbacks deployCallbacks) e
 	return nil
 }
 
-func runWithTUI(orgId, deploymentId string, run *models.DeploymentRun, appUrl string, service *Deployment.DeploymentService) {
+func runWithTUI(orgId, deploymentId string, run *models.DeploymentRun, appUrl string, service *Deployment.DeploymentService) string {
 	statusModel := Deployment.StatusModel{
 		OrganizationId: orgId,
 		DeploymentId:   deploymentId,
@@ -382,6 +446,7 @@ func runWithTUI(orgId, deploymentId string, run *models.DeploymentRun, appUrl st
 
 	statusDisplay := tea.NewProgram(statusModel)
 
+	var finalStatus string
 	var wg sync.WaitGroup
 	wg.Add(1)
 
@@ -404,6 +469,7 @@ func runWithTUI(orgId, deploymentId string, run *models.DeploymentRun, appUrl st
 				extractStatusUpdates(pipelineData, runId, statusDisplay)
 			},
 			onComplete: func(status string) {
+				finalStatus = status
 				statusDisplay.Quit()
 			},
 			onError: func(err error) {
@@ -418,12 +484,14 @@ func runWithTUI(orgId, deploymentId string, run *models.DeploymentRun, appUrl st
 
 	statusDisplay.Run()
 	wg.Wait()
+	return finalStatus
 }
 
-func runWithoutTUI(orgId string, deploymentId string, run *models.DeploymentRun, appUrl string, service *Deployment.DeploymentService) {
+func runWithoutTUI(orgId string, deploymentId string, run *models.DeploymentRun, appUrl string, service *Deployment.DeploymentService) string {
 	printer.Print(fmt.Sprintf("Deployment URL: %s", appUrl))
 	printer.Print("Monitoring deployment progress...")
 
+	var finalStatus string
 	err := streamDeployEvents(orgId, run.ID, deployCallbacks{
 		onVerbose: func(msg string) {
 			printer.Print(fmt.Sprintf("  [verbose] %s", msg))
@@ -435,6 +503,7 @@ func runWithoutTUI(orgId string, deploymentId string, run *models.DeploymentRun,
 			printPipelineUpdates(pipelineData)
 		},
 		onComplete: func(status string) {
+			finalStatus = status
 			switch status {
 			case "succeeded":
 				printer.Success("Deployment completed successfully")
@@ -450,6 +519,7 @@ func runWithoutTUI(orgId string, deploymentId string, run *models.DeploymentRun,
 	if err != nil {
 		printer.Print(fmt.Sprintf("Error: %v", err))
 	}
+	return finalStatus
 }
 
 func printPipelineUpdates(pipelineData map[string]any) {
@@ -604,4 +674,5 @@ func init() {
 	DeployCmd.Flags().StringVar(&envFlag, "env", "", "Environment to deploy (defaults to the environment flagged as the \"development\" type)")
 	DeployCmd.Flags().StringVar(&projectFlag, "project", "", "Project to deploy (defaults to project ID in hx config)")
 	DeployCmd.Flags().StringVar(&appsFlag, "apps", "", "Comma-separated list of apps to deploy, each optionally specifying a build (e.g. app1,app2:abld_xxxx,app3:latest,app4:lastDeployed,app5:latestPreview)")
+	DeployCmd.Flags().StringVar(&outputFormatFlag, "output", "", "Output format. Set to \"json\" to emit a JSON object with deploymentId, runId, deploymentUrl, status, and a messages array on completion instead of streaming human-readable progress.")
 }

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -1,0 +1,34 @@
+package deploy
+
+import (
+	"testing"
+
+	"github.com/Hyphen/cli/pkg/cprint"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeployCmd(t *testing.T) {
+	t.Run("has_an_output_flag", func(t *testing.T) {
+		flag := DeployCmd.Flags().Lookup("output")
+
+		assert.NotNil(t, flag, "deploy command should have an --output flag")
+	})
+
+	t.Run("defaults_the_output_flag_to_empty_string", func(t *testing.T) {
+		flag := DeployCmd.Flags().Lookup("output")
+
+		assert.Equal(t, "", flag.DefValue)
+	})
+}
+
+func TestShouldUseTUI(t *testing.T) {
+	t.Run("returns_false_when_output_format_is_json", func(t *testing.T) {
+		originalFlag := outputFormatFlag
+		outputFormatFlag = cprint.FormatJSON
+		t.Cleanup(func() { outputFormatFlag = originalFlag })
+
+		result := shouldUseTUI()
+
+		assert.False(t, result)
+	})
+}

--- a/pkg/cprint/cprint.go
+++ b/pkg/cprint/cprint.go
@@ -41,9 +41,10 @@ type CPrinter struct {
 	messages []Message
 }
 
-// Message is a user-facing line recorded by the printer. In human mode it
-// streams to stdout as it happens. In json mode it is buffered and emitted
-// as part of the final JSON object produced by Emit.
+// Message is a user-facing line recorded by the printer in all output modes.
+// In human mode it is also streamed to stdout as it happens. In json mode
+// the recorded messages are emitted as part of the final JSON object
+// produced by Emit.
 type Message struct {
 	Level string `json:"level"`
 	Text  string `json:"text"`
@@ -191,7 +192,7 @@ func (p *CPrinter) Error(cmd *cobra.Command, err error) {
 	if p.IsJSON() {
 		return
 	}
-	Error(cmd, err, true)
+	Error(cmd, err, p.verbose)
 }
 
 func (p *CPrinter) Info(message string) {

--- a/pkg/cprint/cprint.go
+++ b/pkg/cprint/cprint.go
@@ -1,7 +1,9 @@
 package cprint
 
 import (
+	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -15,9 +17,36 @@ var (
 	red    = color.New(color.FgRed, color.Bold).SprintFunc()
 )
 
-// CPrinter holds the configuration for printing
+// FormatJSON selects structured JSON output. Callers set it via SetFormat on
+// a CPrinter. Consumers wrapping the CLI (e.g. the deploy-action GitHub
+// wrapper) rely on this contract to parse results.
+const FormatJSON = "json"
+
+// Message levels recorded in the JSON payload.
+const (
+	LevelInfo    = "info"
+	LevelSuccess = "success"
+	LevelWarning = "warning"
+	LevelError   = "error"
+	LevelVerbose = "verbose"
+)
+
+// CPrinter holds the configuration for printing. Safe for concurrent use —
+// callbacks from socket.io event streams call the printer from goroutines
+// other than the main one, so the messages buffer needs a mutex.
 type CPrinter struct {
-	verbose bool
+	verbose  bool
+	format   string
+	mu       sync.Mutex
+	messages []Message
+}
+
+// Message is a user-facing line recorded by the printer. In human mode it
+// streams to stdout as it happens. In json mode it is buffered and emitted
+// as part of the final JSON object produced by Emit.
+type Message struct {
+	Level string `json:"level"`
+	Text  string `json:"text"`
 }
 
 // NewCPrinter creates a new CPrinter instance
@@ -25,6 +54,74 @@ func NewCPrinter(verbose bool) *CPrinter {
 	return &CPrinter{
 		verbose: verbose,
 	}
+}
+
+// SetFormat selects how this printer renders output. The zero value (empty
+// string) is the default human-readable mode. FormatJSON suppresses
+// streaming progress and buffers messages into the JSON payload emitted by
+// Emit.
+func (p *CPrinter) SetFormat(format string) {
+	p.format = format
+}
+
+// IsJSON reports whether the printer is in structured JSON mode.
+func (p *CPrinter) IsJSON() bool {
+	return p.format == FormatJSON
+}
+
+// Messages returns a copy of the messages recorded so far. Exposed mostly
+// for tests; returning a copy keeps callers from mutating printer state.
+func (p *CPrinter) Messages() []Message {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]Message, len(p.messages))
+	copy(out, p.messages)
+	return out
+}
+
+// Emit renders the final output of a command.
+//
+//   - In human mode it is a no-op — individual messages have already been
+//     streamed to stdout as they happened.
+//   - In json mode it merges the caller's result fields with a "messages"
+//     array of everything recorded during the run and writes a single JSON
+//     object to stdout on its own line.
+//
+// The caller owns the result keys. A "messages" key in result is
+// overwritten by the printer's recorded messages — the CLI owns that slot.
+func (p *CPrinter) Emit(result map[string]any) error {
+	if !p.IsJSON() {
+		return nil
+	}
+
+	payload := make(map[string]any, len(result)+1)
+	for k, v := range result {
+		payload[k] = v
+	}
+
+	p.mu.Lock()
+	if p.messages == nil {
+		payload["messages"] = []Message{}
+	} else {
+		msgs := make([]Message, len(p.messages))
+		copy(msgs, p.messages)
+		payload["messages"] = msgs
+	}
+	p.mu.Unlock()
+
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to encode output: %w", err)
+	}
+
+	fmt.Println(string(encoded))
+	return nil
+}
+
+func (p *CPrinter) record(level, text string) {
+	p.mu.Lock()
+	p.messages = append(p.messages, Message{Level: level, Text: text})
+	p.mu.Unlock()
 }
 
 // Standalone functions
@@ -87,57 +184,114 @@ func PrintDetail(label, value string) {
 	fmt.Printf("   %s %s\n", white(label+":"), cyan(value))
 }
 
-// CPrinter methods
+// CPrinter methods — each records the message and, in human mode only,
+// streams it to stdout.
 func (p *CPrinter) Error(cmd *cobra.Command, err error) {
+	p.record(LevelError, err.Error())
+	if p.IsJSON() {
+		return
+	}
 	Error(cmd, err, true)
 }
 
 func (p *CPrinter) Info(message string) {
+	p.record(LevelInfo, message)
+	if p.IsJSON() {
+		return
+	}
 	Info(message)
 }
 
 func (p *CPrinter) YellowPrint(message string) {
+	p.record(LevelInfo, message)
+	if p.IsJSON() {
+		return
+	}
 	YellowPrint(message)
 }
 
 func (p *CPrinter) GreenPrint(message string) {
+	p.record(LevelInfo, message)
+	if p.IsJSON() {
+		return
+	}
 	GreenPrint(message)
 }
 
 func (p *CPrinter) Print(message string) {
+	p.record(LevelInfo, message)
+	if p.IsJSON() {
+		return
+	}
 	Print(message)
 }
 
 func (p *CPrinter) PrintNorm(message string) {
+	p.record(LevelInfo, message)
+	if p.IsJSON() {
+		return
+	}
 	PrintNorm(message)
 }
 
 func (p *CPrinter) Success(message string) {
-	Success(message) //issues/168 introduce always emoji
+	p.record(LevelSuccess, message)
+	if p.IsJSON() {
+		return
+	}
+	Success(message)
 }
 
 func (p *CPrinter) Warning(message string) {
+	p.record(LevelWarning, message)
+	if p.IsJSON() {
+		return
+	}
 	Warning(message)
 }
 
 func (p *CPrinter) OrganizationInfo(orgID string) {
+	p.record(LevelInfo, "Organization ID: "+orgID)
+	if p.IsJSON() {
+		return
+	}
 	OrganizationInfo(orgID, p.verbose)
 }
 
 func (p *CPrinter) Prompt(message string) {
+	// Prompts are interactive and don't make sense in json mode; record
+	// them as info so consumers can see they happened.
+	p.record(LevelInfo, message)
+	if p.IsJSON() {
+		return
+	}
 	Prompt(message, p.verbose)
 }
 
 func (p *CPrinter) PrintHeader(message string) {
+	p.record(LevelInfo, message)
+	if p.IsJSON() {
+		return
+	}
 	PrintHeader(message)
 }
 
 func (p *CPrinter) PrintDetail(label, value string) {
+	p.record(LevelInfo, label+": "+value)
+	if p.IsJSON() {
+		return
+	}
 	PrintDetail(label, value)
 }
 
+// PrintVerbose records and prints only when verbose mode is enabled.
 func (p *CPrinter) PrintVerbose(message string) {
-	if p.verbose {
-		Print(message)
+	if !p.verbose {
+		return
 	}
+	p.record(LevelVerbose, message)
+	if p.IsJSON() {
+		return
+	}
+	Print(message)
 }

--- a/pkg/cprint/cprint.go
+++ b/pkg/cprint/cprint.go
@@ -41,10 +41,11 @@ type CPrinter struct {
 	messages []Message
 }
 
-// Message is a user-facing line recorded by the printer in all output modes.
-// In human mode it is also streamed to stdout as it happens. In json mode
-// the recorded messages are emitted as part of the final JSON object
-// produced by Emit.
+// Message is a user-facing line buffered by the printer in JSON output
+// mode and emitted as part of the final JSON object produced by Emit.
+// In human mode messages are streamed to stdout as they happen and are
+// not buffered, so long-running commands (e.g. hx deploy monitoring a
+// pipeline) don't accumulate them in memory.
 type Message struct {
 	Level string `json:"level"`
 	Text  string `json:"text"`
@@ -185,101 +186,103 @@ func PrintDetail(label, value string) {
 	fmt.Printf("   %s %s\n", white(label+":"), cyan(value))
 }
 
-// CPrinter methods — each records the message and, in human mode only,
-// streams it to stdout.
+// CPrinter methods — in human mode each streams the message to stdout;
+// in JSON mode each records the message into the buffer for Emit to
+// include in the final payload. Messages are not recorded in human mode
+// so long-running commands don't accumulate them in memory.
 func (p *CPrinter) Error(cmd *cobra.Command, err error) {
-	p.record(LevelError, err.Error())
 	if p.IsJSON() {
+		p.record(LevelError, err.Error())
 		return
 	}
 	Error(cmd, err, p.verbose)
 }
 
 func (p *CPrinter) Info(message string) {
-	p.record(LevelInfo, message)
 	if p.IsJSON() {
+		p.record(LevelInfo, message)
 		return
 	}
 	Info(message)
 }
 
 func (p *CPrinter) YellowPrint(message string) {
-	p.record(LevelInfo, message)
 	if p.IsJSON() {
+		p.record(LevelInfo, message)
 		return
 	}
 	YellowPrint(message)
 }
 
 func (p *CPrinter) GreenPrint(message string) {
-	p.record(LevelInfo, message)
 	if p.IsJSON() {
+		p.record(LevelInfo, message)
 		return
 	}
 	GreenPrint(message)
 }
 
 func (p *CPrinter) Print(message string) {
-	p.record(LevelInfo, message)
 	if p.IsJSON() {
+		p.record(LevelInfo, message)
 		return
 	}
 	Print(message)
 }
 
 func (p *CPrinter) PrintNorm(message string) {
-	p.record(LevelInfo, message)
 	if p.IsJSON() {
+		p.record(LevelInfo, message)
 		return
 	}
 	PrintNorm(message)
 }
 
 func (p *CPrinter) Success(message string) {
-	p.record(LevelSuccess, message)
 	if p.IsJSON() {
+		p.record(LevelSuccess, message)
 		return
 	}
 	Success(message)
 }
 
 func (p *CPrinter) Warning(message string) {
-	p.record(LevelWarning, message)
 	if p.IsJSON() {
+		p.record(LevelWarning, message)
 		return
 	}
 	Warning(message)
 }
 
 func (p *CPrinter) OrganizationInfo(orgID string) {
-	p.record(LevelInfo, "Organization ID: "+orgID)
 	if p.IsJSON() {
+		p.record(LevelInfo, "Organization ID: "+orgID)
 		return
 	}
 	OrganizationInfo(orgID, p.verbose)
 }
 
 func (p *CPrinter) Prompt(message string) {
-	// Prompts are interactive and don't make sense in json mode; record
-	// them as info so consumers can see they happened.
-	p.record(LevelInfo, message)
 	if p.IsJSON() {
+		// Prompts are interactive and don't make sense in json mode;
+		// record them as info so consumers can see they happened.
+		p.record(LevelInfo, message)
 		return
 	}
 	Prompt(message, p.verbose)
 }
 
 func (p *CPrinter) PrintHeader(message string) {
-	p.record(LevelInfo, message)
 	if p.IsJSON() {
+		p.record(LevelInfo, message)
 		return
 	}
 	PrintHeader(message)
 }
 
 func (p *CPrinter) PrintDetail(label, value string) {
-	p.record(LevelInfo, label+": "+value)
 	if p.IsJSON() {
+		p.record(LevelInfo, label+": "+value)
 		return
 	}
 	PrintDetail(label, value)
@@ -290,8 +293,8 @@ func (p *CPrinter) PrintVerbose(message string) {
 	if !p.verbose {
 		return
 	}
-	p.record(LevelVerbose, message)
 	if p.IsJSON() {
+		p.record(LevelVerbose, message)
 		return
 	}
 	Print(message)

--- a/pkg/cprint/cprint_test.go
+++ b/pkg/cprint/cprint_test.go
@@ -65,13 +65,12 @@ func TestCPrinterHumanMode(t *testing.T) {
 			assert.Contains(t, output, "the message", "expected %s to stream the message", m.name)
 		})
 
-		t.Run(m.name+"_records_the_message", func(t *testing.T) {
+		t.Run(m.name+"_does_not_buffer_in_human_mode", func(t *testing.T) {
 			printer := NewCPrinter(false)
 
 			captureStdout(t, func() { m.call(printer) })
 
-			assert.Len(t, printer.Messages(), 1, "expected %s to record exactly one message", m.name)
-			assert.Contains(t, printer.Messages()[0].Text, "the message")
+			assert.Empty(t, printer.Messages(), "expected %s to skip recording in human mode", m.name)
 		})
 	}
 }

--- a/pkg/cprint/cprint_test.go
+++ b/pkg/cprint/cprint_test.go
@@ -1,0 +1,315 @@
+package cprint
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// captureStdout redirects os.Stdout while f runs and returns what was
+// written. The CPrinter methods write to os.Stdout via fmt.Printf, so this
+// is how we verify their actual output behavior.
+func captureStdout(t *testing.T, f func()) string {
+	t.Helper()
+
+	originalStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = originalStdout })
+
+	f()
+	w.Close()
+
+	out, readErr := io.ReadAll(r)
+	if readErr != nil {
+		t.Fatalf("failed to read captured stdout: %v", readErr)
+	}
+	return string(out)
+}
+
+func TestCPrinterHumanMode(t *testing.T) {
+	methods := []struct {
+		name string
+		call func(p *CPrinter)
+	}{
+		{"Print", func(p *CPrinter) { p.Print("the message") }},
+		{"PrintNorm", func(p *CPrinter) { p.PrintNorm("the message") }},
+		{"Info", func(p *CPrinter) { p.Info("the message") }},
+		{"Success", func(p *CPrinter) { p.Success("the message") }},
+		{"Warning", func(p *CPrinter) { p.Warning("the message") }},
+		{"YellowPrint", func(p *CPrinter) { p.YellowPrint("the message") }},
+		{"GreenPrint", func(p *CPrinter) { p.GreenPrint("the message") }},
+		{"PrintHeader", func(p *CPrinter) { p.PrintHeader("the message") }},
+		{"PrintDetail", func(p *CPrinter) { p.PrintDetail("aLabel", "the message") }},
+		{"OrganizationInfo", func(p *CPrinter) { p.OrganizationInfo("the message") }},
+		{"Prompt", func(p *CPrinter) { p.Prompt("the message") }},
+	}
+
+	for _, m := range methods {
+		t.Run(m.name+"_streams_to_stdout", func(t *testing.T) {
+			printer := NewCPrinter(false)
+
+			output := captureStdout(t, func() { m.call(printer) })
+
+			assert.Contains(t, output, "the message", "expected %s to stream the message", m.name)
+		})
+
+		t.Run(m.name+"_records_the_message", func(t *testing.T) {
+			printer := NewCPrinter(false)
+
+			captureStdout(t, func() { m.call(printer) })
+
+			assert.Len(t, printer.Messages(), 1, "expected %s to record exactly one message", m.name)
+			assert.Contains(t, printer.Messages()[0].Text, "the message")
+		})
+	}
+}
+
+func TestCPrinterJSONMode(t *testing.T) {
+	methods := []struct {
+		name string
+		call func(p *CPrinter)
+	}{
+		{"Print", func(p *CPrinter) { p.Print("the message") }},
+		{"PrintNorm", func(p *CPrinter) { p.PrintNorm("the message") }},
+		{"Info", func(p *CPrinter) { p.Info("the message") }},
+		{"Success", func(p *CPrinter) { p.Success("the message") }},
+		{"Warning", func(p *CPrinter) { p.Warning("the message") }},
+		{"YellowPrint", func(p *CPrinter) { p.YellowPrint("the message") }},
+		{"GreenPrint", func(p *CPrinter) { p.GreenPrint("the message") }},
+		{"PrintHeader", func(p *CPrinter) { p.PrintHeader("the message") }},
+		{"PrintDetail", func(p *CPrinter) { p.PrintDetail("aLabel", "the message") }},
+		{"OrganizationInfo", func(p *CPrinter) { p.OrganizationInfo("the message") }},
+		{"Prompt", func(p *CPrinter) { p.Prompt("the message") }},
+	}
+
+	for _, m := range methods {
+		t.Run(m.name+"_writes_nothing_to_stdout", func(t *testing.T) {
+			printer := NewCPrinter(false)
+			printer.SetFormat(FormatJSON)
+
+			output := captureStdout(t, func() { m.call(printer) })
+
+			assert.Empty(t, output, "expected %s to suppress stdout in json mode", m.name)
+		})
+
+		t.Run(m.name+"_still_records_the_message", func(t *testing.T) {
+			printer := NewCPrinter(false)
+			printer.SetFormat(FormatJSON)
+
+			captureStdout(t, func() { m.call(printer) })
+
+			assert.Len(t, printer.Messages(), 1, "expected %s to record even when silent", m.name)
+			assert.Contains(t, printer.Messages()[0].Text, "the message")
+		})
+	}
+}
+
+func TestCPrinterRecordsLevels(t *testing.T) {
+	t.Run("Info_records_info_level", func(t *testing.T) {
+		printer := NewCPrinter(false)
+		printer.SetFormat(FormatJSON)
+
+		printer.Info("the message")
+
+		assert.Equal(t, "info", printer.Messages()[0].Level)
+	})
+
+	t.Run("Success_records_success_level", func(t *testing.T) {
+		printer := NewCPrinter(false)
+		printer.SetFormat(FormatJSON)
+
+		printer.Success("the message")
+
+		assert.Equal(t, "success", printer.Messages()[0].Level)
+	})
+
+	t.Run("Warning_records_warning_level", func(t *testing.T) {
+		printer := NewCPrinter(false)
+		printer.SetFormat(FormatJSON)
+
+		printer.Warning("the message")
+
+		assert.Equal(t, "warning", printer.Messages()[0].Level)
+	})
+
+	t.Run("PrintVerbose_records_verbose_level_when_verbose_enabled", func(t *testing.T) {
+		printer := NewCPrinter(true)
+		printer.SetFormat(FormatJSON)
+
+		printer.PrintVerbose("the message")
+
+		assert.Len(t, printer.Messages(), 1)
+		assert.Equal(t, "verbose", printer.Messages()[0].Level)
+	})
+
+	t.Run("PrintVerbose_records_nothing_when_verbose_disabled", func(t *testing.T) {
+		printer := NewCPrinter(false)
+		printer.SetFormat(FormatJSON)
+
+		printer.PrintVerbose("a message")
+
+		assert.Empty(t, printer.Messages())
+	})
+}
+
+func TestCPrinterEmit(t *testing.T) {
+	t.Run("writes_nothing_when_not_in_json_mode", func(t *testing.T) {
+		printer := NewCPrinter(false)
+
+		output := captureStdout(t, func() {
+			assert.NoError(t, printer.Emit(map[string]any{"foo": "bar"}))
+		})
+
+		assert.Empty(t, output)
+	})
+
+	t.Run("emits_a_single_json_object_with_the_result_fields_and_a_messages_array", func(t *testing.T) {
+		printer := NewCPrinter(false)
+		printer.SetFormat(FormatJSON)
+		printer.Info("the first message")
+		printer.Success("the second message")
+
+		output := captureStdout(t, func() {
+			assert.NoError(t, printer.Emit(map[string]any{
+				"buildId": "abld_the_id",
+				"appId":   "app_the_app",
+			}))
+		})
+
+		var decoded struct {
+			BuildID  string    `json:"buildId"`
+			AppID    string    `json:"appId"`
+			Messages []Message `json:"messages"`
+		}
+		assert.NoError(t, json.Unmarshal([]byte(output), &decoded))
+		assert.Equal(t, "abld_the_id", decoded.BuildID)
+		assert.Equal(t, "app_the_app", decoded.AppID)
+		assert.Equal(t, []Message{
+			{Level: "info", Text: "the first message"},
+			{Level: "success", Text: "the second message"},
+		}, decoded.Messages)
+	})
+
+	t.Run("emits_an_empty_messages_array_when_no_messages_were_recorded", func(t *testing.T) {
+		printer := NewCPrinter(false)
+		printer.SetFormat(FormatJSON)
+
+		output := captureStdout(t, func() {
+			assert.NoError(t, printer.Emit(map[string]any{"status": "succeeded"}))
+		})
+
+		assert.Contains(t, output, `"messages":[]`)
+	})
+
+	t.Run("produces_a_single_line_of_output", func(t *testing.T) {
+		printer := NewCPrinter(false)
+		printer.SetFormat(FormatJSON)
+		printer.Info("the message")
+
+		output := captureStdout(t, func() {
+			assert.NoError(t, printer.Emit(map[string]any{"foo": "bar"}))
+		})
+
+		// Exactly one trailing newline from fmt.Println.
+		assert.Equal(t, 1, lineCount(output), "expected a single json line in: %q", output)
+	})
+
+	t.Run("produces_valid_json", func(t *testing.T) {
+		printer := NewCPrinter(false)
+		printer.SetFormat(FormatJSON)
+		printer.Info("the message")
+
+		output := captureStdout(t, func() {
+			assert.NoError(t, printer.Emit(map[string]any{"foo": "bar"}))
+		})
+
+		assert.True(t, json.Valid([]byte(output)), "output must be valid JSON: %q", output)
+	})
+
+	t.Run("overwrites_any_messages_key_provided_by_the_caller", func(t *testing.T) {
+		printer := NewCPrinter(false)
+		printer.SetFormat(FormatJSON)
+		printer.Info("the real message")
+
+		output := captureStdout(t, func() {
+			assert.NoError(t, printer.Emit(map[string]any{
+				"status":   "succeeded",
+				"messages": "a caller-supplied value",
+			}))
+		})
+
+		// The caller's "messages" must not survive; the printer owns that slot.
+		assert.NotContains(t, output, "a caller-supplied value")
+		assert.Contains(t, output, "the real message")
+	})
+}
+
+func TestCPrinterConcurrentRecording(t *testing.T) {
+	t.Run("record_is_safe_to_call_concurrently", func(t *testing.T) {
+		printer := NewCPrinter(false)
+		printer.SetFormat(FormatJSON)
+
+		var wg sync.WaitGroup
+		workers := 16
+		perWorker := 64
+		wg.Add(workers)
+		for i := 0; i < workers; i++ {
+			go func() {
+				defer wg.Done()
+				for j := 0; j < perWorker; j++ {
+					printer.Info("the message")
+				}
+			}()
+		}
+		wg.Wait()
+
+		assert.Len(t, printer.Messages(), workers*perWorker)
+	})
+}
+
+func TestCPrinterIsJSON(t *testing.T) {
+	t.Run("returns_false_by_default", func(t *testing.T) {
+		printer := NewCPrinter(false)
+
+		assert.False(t, printer.IsJSON())
+	})
+
+	t.Run("returns_true_when_format_is_json", func(t *testing.T) {
+		printer := NewCPrinter(false)
+		printer.SetFormat(FormatJSON)
+
+		assert.True(t, printer.IsJSON())
+	})
+
+	t.Run("returns_false_for_unknown_format", func(t *testing.T) {
+		printer := NewCPrinter(false)
+		printer.SetFormat("yaml")
+
+		assert.False(t, printer.IsJSON())
+	})
+}
+
+func lineCount(s string) int {
+	if s == "" {
+		return 0
+	}
+	lines := 0
+	for _, r := range s {
+		if r == '\n' {
+			lines++
+		}
+	}
+	// Count the trailing non-newline content as a line, too.
+	if s[len(s)-1] != '\n' {
+		lines++
+	}
+	return lines
+}

--- a/pkg/cprint/cprint_test.go
+++ b/pkg/cprint/cprint_test.go
@@ -21,10 +21,14 @@ func captureStdout(t *testing.T, f func()) string {
 	if err != nil {
 		t.Fatalf("failed to create pipe: %v", err)
 	}
+	// Restore os.Stdout immediately after f() so the rest of the subtest
+	// (assertions, t.Logf, etc.) writes to the real stdout. t.Cleanup is a
+	// safety net in case f panics before we get here.
 	os.Stdout = w
 	t.Cleanup(func() { os.Stdout = originalStdout })
 
 	f()
+	os.Stdout = originalStdout
 	w.Close()
 
 	out, readErr := io.ReadAll(r)

--- a/pkg/dockerutil/dockerutil.go
+++ b/pkg/dockerutil/dockerutil.go
@@ -110,8 +110,12 @@ func Build(dockerFilePathOrDir, name, tag string, verbose bool) (string, string,
 
 	cmd := exec.Command("docker", args...)
 
+	// Docker's build output is progress, not structured data. Sending it to
+	// stderr keeps our stdout clean for structured output modes (e.g.
+	// `hx build --output json`) while still letting the user see progress
+	// in a terminal (terminals render stderr).
 	if verbose {
-		cmd.Stdout = os.Stdout
+		cmd.Stdout = os.Stderr
 		cmd.Stderr = os.Stderr
 	}
 


### PR DESCRIPTION
## Summary

This PR:

- Adds `--output json` to `hx build` and `hx deploy`, emitting a single structured JSON object on stdout with a `messages` array capturing what would have streamed in human mode
- Extends `cprint.CPrinter` with a format-aware mode so commands can opt into JSON output without each reinventing suppression + buffering
- Routes `docker build` verbose output to stderr so stdout stays pure in JSON mode (standard Unix split)
- Unifies exit code behavior so a non-succeeded `hx deploy` run exits non-zero in every output mode

## Payload shape

`hx build --output json` (success):

```json
{"status":"succeeded","buildId":"abld_...","appId":"app_...","projectId":"proj_...","organizationId":"org_...","buildUrl":"https://...","messages":[{"level":"info","text":"..."}]}
```

`hx deploy --output json` (success):

```json
{"status":"succeeded","deploymentId":"depl_...","runId":"drun_...","deploymentUrl":"https://...","messages":[...]}
```

On failure, both commands emit `{"status":"failed","reason":"...","messages":[...]}` plus any fields known before the error (e.g. `deploymentId` for deploy), and still exit non-zero. Cobra's error/usage output is silenced in JSON mode so it doesn't corrupt stdout after the payload.

## Behavior changes worth reviewer attention

- **`hx deploy` on failed/canceled runs now exits non-zero in every mode.** Previously human mode would exit 0 regardless of the final status, which meant CI pipelines couldn't detect a failed deployment via exit code alone. The streaming output already showed the status in human mode, so cobra's redundant `Error: deployment ended with status ...` line is silenced.
- **`hx deploy` on a not-ready deployment now exits non-zero.** Previously it printed the readiness issues and exited 0.
- **Docker `-v` build progress moves from stdout to stderr.** Matches the convention of other build tools; lets you pipe stdout without extra flags.

## Concurrency

`cprint.CPrinter.messages` is accessed from both the main goroutine and socket.io event-dispatch goroutines during deploy runs. The buffer is guarded by a `sync.Mutex`; a dedicated concurrent-recording test runs under `go test -race` to keep it honest.

## Test plan

- [x] Unit tests pass with `-race` (`go test -race ./...`)
- [x] Manual: `hx build --output json | jq` prints clean JSON (human progress suppressed)
- [x] Manual: `hx deploy --output json | jq` prints clean JSON on terminal-state
- [x] Manual: `hx build -v --output json | jq` still clean (docker progress on stderr)
- [x] Manual: `hx build --output json 2>/dev/null` is a single JSON line
- [x] Reviewer: verify failure payload for a deliberately broken deploy/build (`reason` field, non-zero exit, no stdout pollution)

## Follow-ups (out of scope here)

- Full integration tests for failure paths need a DI refactor of the underlying services; not worth bundling.
- `reason` is currently the stringified error; a future iteration could give it structure (error code, etc.) once a consumer needs it.
