### PR TITLE
fix(socketio): use sync.Once for connectedCh close to prevent panic on reconnect

### DIFF
--- a/pkg/socketio/service.go
+++ b/pkg/socketio/service.go
@@ -106,12 +106,7 @@ func (s *Service) Connect(orgId string) error {
 			s.logVerbose("Connected successfully")
 		}
 
-		// Closing connectedCh signals waiters in Connect that the initial
-		// connection succeeded. We only want this to happen on the first
-		// connect; sync.Once makes that a structural invariant rather than
-		// relying on s.connected, which the disconnect handler legitimately
-		// flips back to false on a transient blip.
-		s.connectedOnce.Do(func() { close(s.connectedCh) })
+		s.markConnected()
 	})
 
 	client.On("connect_error", func(args ...any) {
@@ -134,6 +129,15 @@ func (s *Service) Connect(orgId string) error {
 		s.logVerbose("Connection timed out after 10 seconds")
 		return errors.New("Socket.io connection timeout")
 	}
+}
+
+// markConnected closes connectedCh exactly once, signalling waiters in Connect
+// that the initial connection succeeded. sync.Once makes "connectedCh is
+// closed exactly once" a property of the type rather than a state machine that
+// the disconnect path can invalidate by flipping s.connected on a transient
+// reconnect, which previously caused close-of-closed-channel panics.
+func (s *Service) markConnected() {
+	s.connectedOnce.Do(func() { close(s.connectedCh) })
 }
 
 func (s *Service) On(event string, handler func(...any)) {

--- a/pkg/socketio/service.go
+++ b/pkg/socketio/service.go
@@ -21,6 +21,7 @@ type Service struct {
 	mu              sync.Mutex
 	connected       bool
 	connectedCh     chan struct{}
+	connectedOnce   sync.Once
 	verboseCallback func(string)
 }
 
@@ -99,13 +100,18 @@ func (s *Service) Connect(orgId string) error {
 		s.connected = true
 		s.mu.Unlock()
 
-		// If this is a reconnect, the connected channel will already have been closed, and trying to close it again will panic
 		if wasConnected {
 			s.logVerbose("Reconnected successfully")
 		} else {
 			s.logVerbose("Connected successfully")
-			close(s.connectedCh)
 		}
+
+		// Closing connectedCh signals waiters in Connect that the initial
+		// connection succeeded. We only want this to happen on the first
+		// connect; sync.Once makes that a structural invariant rather than
+		// relying on s.connected, which the disconnect handler legitimately
+		// flips back to false on a transient blip.
+		s.connectedOnce.Do(func() { close(s.connectedCh) })
 	})
 
 	client.On("connect_error", func(args ...any) {

--- a/pkg/socketio/service_test.go
+++ b/pkg/socketio/service_test.go
@@ -1,0 +1,32 @@
+package socketio
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestService(t *testing.T) {
+	t.Run("markConnected_closes_connectedCh_on_first_call", func(t *testing.T) {
+		s := NewService()
+
+		s.markConnected()
+
+		select {
+		case <-s.connectedCh:
+			// connectedCh closed as expected
+		default:
+			t.Fatal("expected connectedCh to be closed after markConnected()")
+		}
+	})
+
+	t.Run("markConnected_is_idempotent_across_repeated_calls", func(t *testing.T) {
+		s := NewService()
+
+		assert.NotPanics(t, func() {
+			s.markConnected()
+			s.markConnected()
+			s.markConnected()
+		}, "repeated markConnected calls must not panic on close-of-closed-channel")
+	})
+}


### PR DESCRIPTION
## Summary

This PR:

- Fixes a `panic: close of closed channel` in `pkg/socketio/service.go` that triggers when the WebSocket reconnects during a long-running command — the same race described in #260.
- Replaces the `if !wasConnected { close(connectedCh) }` pattern with `connectedOnce.Do(func() { close(connectedCh) })`, making "`connectedCh` is closed exactly once" a property of the type rather than a state machine that the disconnect path can invalidate.
- Adds a comment explaining the invariant so a future change can't reintroduce the race by accident.

The bug has been present since v0.21.0 (introduced in #231) but became visible to integrations starting v0.27.0, when `hx deploy --output json` (#259) made the panic fail callers that parse the trailing JSON. Reproduced via `Hyphen/deploy-action` runs against a long deploy:

| Run | Wall time | Outcome |
| --- | --- | --- |
| https://github.com/half-ogre/hyphen-preview-env-demo/actions/runs/25005706699 | ~5 min | succeeded |
| https://github.com/half-ogre/hyphen-preview-env-demo/actions/runs/25006288386 | ~11.5 min | panicked at `service.go:107` |

Full root-cause analysis in #260.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean (verified locally).
- [x] Tag a release candidate and re-run the long-deploy workflow against `Hyphen/deploy-action` (https://github.com/half-ogre/hyphen-preview-env-demo/actions/workflows/test-deploy-action.yml) until it stays green across multiple runs — needs a deploy long enough to flap the WebSocket.
- [x] Spot-check that other socketio-using commands still log "Reconnected successfully" on a reconnect after the change.