### PR TITLE
fix: initialize printer in SetProject so hx auth doesn't panic

### DIFF
--- a/cmd/setproject/setproject.go
+++ b/cmd/setproject/setproject.go
@@ -13,13 +13,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// printer is a package-level var because flags.VerboseFlag isn't bound
+// until cobra parses flags at runtime, so it can't be initialized in
+// init(). It's lazily initialized at each entry point —
+// SetProjectCmd.RunE and SetProject — with a nil-check on the latter
+// so it doesn't clobber state set on the printer earlier in the
+// command's lifecycle.
+// TODO: thread a *CPrinter through the call signatures and drop the
+// package-level mutable state.
 var (
 	printer *cprint.CPrinter
 )
 
 var SetProjectCmd = &cobra.Command{
 	Use:   "set-project <id/alternate_id>",
-	Short: "Set the defaultd project",
+	Short: "Set the default project",
 	Long:  `Set the default project for the Hyphen CLI to use.`,
 	Args:  cobra.MaximumNArgs(1),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
@@ -43,6 +51,13 @@ var SetProjectCmd = &cobra.Command{
 }
 
 func SetProject(cmd *cobra.Command, organizationID, projectID string) error {
+	// SetProject is called both from SetProjectCmd.RunE (which already
+	// initializes printer) and directly from setorg.SetOrganization
+	// (where RunE never fires). Initialize only if not already set so
+	// we don't clobber state.
+	if printer == nil {
+		printer = cprint.NewCPrinter(flags.VerboseFlag)
+	}
 	projectService := projects.NewService(organizationID)
 	var project models.Project
 	if projectID == "" {
@@ -61,12 +76,18 @@ func SetProject(cmd *cobra.Command, organizationID, projectID string) error {
 		project = proj
 	}
 
+	if project.ID == nil {
+		err := fmt.Errorf("project %q has no ID; cannot set as default", project.Name)
+		printer.Error(cmd, err)
+		return err
+	}
+
 	err := config.UpsertGlobalProject(project)
 	if err != nil {
 		printer.Error(cmd, fmt.Errorf("failed to update default project: %v", err))
 		return err
 	}
-	printer.Success(fmt.Sprintf("successfully update default project to %s (%s)", project.Name, *project.ID))
+	printer.Success(fmt.Sprintf("successfully updated default project to %s (%s)", project.Name, *project.ID))
 
 	return nil
 }


### PR DESCRIPTION
This PR:

- Initializes the package-level `printer` at the top of `setproject.SetProject` so it isn't nil when the function is invoked outside its own cobra `RunE`. Mirrors the existing pattern in `setorg.SetOrganization`.
- Fixes the `hx auth` panic in #262 — `setorg.SetOrganization` calls `SetProject` directly (setorg.go:87), so `RunE` never fires and `printer.Success` at setproject.go:69 hits a nil receiver.
- Adds a doc comment on the package-level `printer` var explaining why it must be lazy-initialized (`flags.VerboseFlag` isn't bound until cobra parses flags), with a TODO to thread it through call signatures and drop the package-level mutable state.
- Adds a nil-check on `project.ID` before dereferencing it for the success message — `Project.ID` is `*string`.
- Fixes pre-existing typos in the same file: "defaultd" -> "default" in the cobra `Short`, and "successfully update" -> "successfully updated" in the success message.

Fixes #262

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `hx auth` completes successfully against an org with exactly one project (the path that triggered the original panic)
- [ ] `hx auth` against a multi-project org still prompts and completes
- [ ] `hx set-project <id>` still works on its own

## Notes for reviewers

- No tests added: `setproject`, `setorg`, and `auth` packages have zero existing tests, and adding one for this 1-line fix would require a cobra-command harness disproportionate to the change.
- `*project.ID` is dereferenced unchecked elsewhere in the codebase (`cmd/project/list`, `cmd/project/get`, `pkg/helpers/selectProject`). This PR only addresses the call site that was already in scope.