### PR TITLE
fix: [1897] support adding new apps to current deployment

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -180,6 +180,14 @@ func runDeployBody(cmd *cobra.Command, args []string) (map[string]any, error) {
 
 	result["deploymentId"] = selectedDeployment.ID
 
+	if appsFlag == "" {
+		if updated, err := ensureLocalAppInDeployment(service, orgId, selectedDeployment); err != nil {
+			return result, err
+		} else if updated != nil {
+			selectedDeployment = *updated
+		}
+	}
+
 	if !selectedDeployment.IsReady {
 		printer.Print("❌ There are issues blocking this deployment from being run.")
 		issues := []string{}
@@ -245,7 +253,16 @@ func runDeployBody(cmd *cobra.Command, args []string) (map[string]any, error) {
 		for _, pa := range parsedApps {
 			deployApp, err := resolveDeploymentApp(pa.ID, selectedDeployment)
 			if err != nil {
-				return result, err
+				printer.Print(fmt.Sprintf("Adding app %q to deployment with default settings", pa.ID))
+				updated, addErr := service.AddAppToDeployment(orgId, selectedDeployment.ID, pa.ID)
+				if addErr != nil {
+					return result, fmt.Errorf("failed to add app %q to deployment: %w", pa.ID, addErr)
+				}
+				selectedDeployment = *updated
+				deployApp, err = resolveDeploymentApp(pa.ID, selectedDeployment)
+				if err != nil {
+					return result, fmt.Errorf("failed to resolve app %q after adding to deployment: %w", pa.ID, err)
+				}
 			}
 
 			if noBuild {
@@ -660,6 +677,33 @@ func parseAppsFlag(appsFlag string) ([]parsedApp, error) {
 		return nil, fmt.Errorf("--apps flag is empty")
 	}
 	return result, nil
+}
+
+// ensureLocalAppInDeployment makes sure the app referenced by the local .hx
+// config is part of the deployment. If the local config can't be read or
+// doesn't have an app id, it's a no-op. If the app is missing from the
+// deployment, it's added with default settings and the updated deployment is
+// returned. Returns (nil, nil) when no change was made.
+func ensureLocalAppInDeployment(service *Deployment.DeploymentService, orgId string, deployment models.Deployment) (*models.Deployment, error) {
+	cfg, err := config.RestoreLocalConfig()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to restore config: %w", err)
+	}
+	if cfg.AppId == nil {
+		return nil, nil
+	}
+	if _, err := resolveDeploymentApp(*cfg.AppId, deployment); err == nil {
+		return nil, nil
+	}
+	printer.Print(fmt.Sprintf("Adding app %q to deployment with default settings", *cfg.AppId))
+	updated, err := service.AddAppToDeployment(orgId, deployment.ID, *cfg.AppId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add app %q to deployment: %w", *cfg.AppId, err)
+	}
+	return updated, nil
 }
 
 func resolveDeploymentApp(identifier string, deployment models.Deployment) (*models.DeploymentApp, error) {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -250,19 +250,25 @@ func runDeployBody(cmd *cobra.Command, args []string) (map[string]any, error) {
 			return result, err
 		}
 
+		var missingApps []string
+		for _, pa := range parsedApps {
+			if _, err := resolveDeploymentApp(pa.ID, selectedDeployment); err != nil {
+				missingApps = append(missingApps, pa.ID)
+			}
+		}
+		if len(missingApps) > 0 {
+			printer.Print(fmt.Sprintf("Adding app(s) %v to deployment with default settings", missingApps))
+			updated, addErr := service.AddAppsToDeployment(orgId, selectedDeployment.ID, missingApps)
+			if addErr != nil {
+				return result, fmt.Errorf("failed to add apps %v to deployment: %w", missingApps, addErr)
+			}
+			selectedDeployment = *updated
+		}
+
 		for _, pa := range parsedApps {
 			deployApp, err := resolveDeploymentApp(pa.ID, selectedDeployment)
 			if err != nil {
-				printer.Print(fmt.Sprintf("Adding app %q to deployment with default settings", pa.ID))
-				updated, addErr := service.AddAppToDeployment(orgId, selectedDeployment.ID, pa.ID)
-				if addErr != nil {
-					return result, fmt.Errorf("failed to add app %q to deployment: %w", pa.ID, addErr)
-				}
-				selectedDeployment = *updated
-				deployApp, err = resolveDeploymentApp(pa.ID, selectedDeployment)
-				if err != nil {
-					return result, fmt.Errorf("failed to resolve app %q after adding to deployment: %w", pa.ID, err)
-				}
+				return result, fmt.Errorf("failed to resolve app %q after adding to deployment: %w", pa.ID, err)
 			}
 
 			if noBuild {
@@ -699,7 +705,7 @@ func ensureLocalAppInDeployment(service *Deployment.DeploymentService, orgId str
 		return nil, nil
 	}
 	printer.Print(fmt.Sprintf("Adding app %q to deployment with default settings", *cfg.AppId))
-	updated, err := service.AddAppToDeployment(orgId, deployment.ID, *cfg.AppId)
+	updated, err := service.AddAppsToDeployment(orgId, deployment.ID, []string{*cfg.AppId})
 	if err != nil {
 		return nil, fmt.Errorf("failed to add app %q to deployment: %w", *cfg.AppId, err)
 	}

--- a/internal/deployment/service.go
+++ b/internal/deployment/service.go
@@ -236,13 +236,65 @@ func (ds *DeploymentService) GetDeployment(organizationId, deploymentId string) 
 	return &deployment, nil
 }
 
-// AddAppToDeployment patches a deployment to include a new app entry. The new
-// entry is sent without deploymentSettings, so the API fills in defaults
+// patchDeploymentApp mirrors the subset of fields that PATCH
+// /deployments/:id accepts on each app entry. Decoding the GET response into
+// this shape naturally drops fields the PATCH validator rejects — notably
+// projectEnvironment, which is part of the GET response but not part of the
+// PATCH input schema (additionalProperties: false).
+type patchDeploymentApp struct {
+	Project            *patchProjectRef         `json:"project,omitempty"`
+	App                patchAppRef              `json:"app"`
+	DeploymentSettings *patchDeploymentSettings `json:"deploymentSettings,omitempty"`
+}
+
+type patchProjectRef struct {
+	ID          string `json:"id"`
+	AlternateID string `json:"alternateId,omitempty"`
+	Name        string `json:"name,omitempty"`
+}
+
+type patchAppRef struct {
+	ID          string `json:"id"`
+	AlternateID string `json:"alternateId,omitempty"`
+	Name        string `json:"name,omitempty"`
+}
+
+type patchDeploymentSettings struct {
+	Targets        []patchTarget   `json:"targets"`
+	Path           string          `json:"path,omitempty"`
+	Hostname       string          `json:"hostname,omitempty"`
+	DNS            *patchDNS       `json:"dns,omitempty"`
+	Availability   string          `json:"availability"`
+	Scale          string          `json:"scale"`
+	TrafficRegions []string        `json:"trafficRegions"`
+	Advanced       json.RawMessage `json:"advanced,omitempty"`
+}
+
+type patchTarget struct {
+	ID   string `json:"id"`
+	Type string `json:"type,omitempty"`
+}
+
+type patchDNS struct {
+	ZoneName string `json:"zoneName"`
+}
+
+// AddAppsToDeployment patches a deployment to include the given app ids. Each
+// new entry is sent without deploymentSettings, so the API fills in defaults
 // (availability/scale/trafficRegions and the org's first cloud integration as
-// the target). Existing apps are re-sent so they're preserved — the PATCH
-// endpoint replaces the apps array wholesale.
-func (ds *DeploymentService) AddAppToDeployment(organizationId, deploymentId, appId string) (*models.Deployment, error) {
-	deploymentUrl := fmt.Sprintf("%s/api/organizations/%s/deployments/%s", ds.baseUrl, organizationId, deploymentId)
+// the target). The PATCH replaces the apps array wholesale, so existing apps
+// are re-sent verbatim from the GET response.
+func (ds *DeploymentService) AddAppsToDeployment(organizationId, deploymentId string, appIds []string) (*models.Deployment, error) {
+	if len(appIds) == 0 {
+		return ds.GetDeployment(organizationId, deploymentId)
+	}
+
+	deploymentUrl := fmt.Sprintf(
+		"%s/api/organizations/%s/deployments/%s",
+		ds.baseUrl,
+		url.PathEscape(organizationId),
+		url.PathEscape(deploymentId),
+	)
 
 	getReq, err := http.NewRequest("GET", deploymentUrl, nil)
 	if err != nil {
@@ -256,35 +308,39 @@ func (ds *DeploymentService) AddAppToDeployment(organizationId, deploymentId, ap
 	if getResp.StatusCode != http.StatusOK {
 		return nil, errors.HandleHTTPError(getResp)
 	}
-	getBody, err := io.ReadAll(getResp.Body)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to read response body")
-	}
 
 	var current struct {
-		Apps []map[string]any `json:"apps"`
+		Apps []patchDeploymentApp `json:"apps"`
 	}
-	if err := json.Unmarshal(getBody, &current); err != nil {
+	if err := json.NewDecoder(getResp.Body).Decode(&current); err != nil {
 		return nil, errors.Wrap(err, "Failed to parse JSON response")
 	}
 
-	for _, app := range current.Apps {
-		if settings, ok := app["deploymentSettings"].(map[string]any); ok {
-			delete(settings, "projectEnvironment")
-			if dns, ok := settings["dns"].(map[string]any); ok {
-				if zoneName, _ := dns["zoneName"].(string); zoneName == "" {
-					delete(settings, "dns")
-				}
-			}
+	// Apps without DNS come back as `dns: {}` in the GET response (the GET
+	// schema only exposes zoneName). PATCH requires zoneName when dns is
+	// present, so drop the empty DNS object before re-sending. Same for an
+	// `advanced: null` from the wire — the PATCH schema requires an object.
+	for i := range current.Apps {
+		s := current.Apps[i].DeploymentSettings
+		if s == nil {
+			continue
+		}
+		if s.DNS != nil && s.DNS.ZoneName == "" {
+			s.DNS = nil
+		}
+		if string(s.Advanced) == "null" {
+			s.Advanced = nil
 		}
 	}
 
-	apps := append(current.Apps, map[string]any{
-		"app": map[string]any{"id": appId},
-	})
+	for _, appId := range appIds {
+		current.Apps = append(current.Apps, patchDeploymentApp{
+			App: patchAppRef{ID: appId},
+		})
+	}
 
 	requestBody, err := json.Marshal(map[string]any{
-		"apps": apps,
+		"apps": current.Apps,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to marshal request body")

--- a/internal/deployment/service.go
+++ b/internal/deployment/service.go
@@ -236,6 +236,81 @@ func (ds *DeploymentService) GetDeployment(organizationId, deploymentId string) 
 	return &deployment, nil
 }
 
+// AddAppToDeployment patches a deployment to include a new app entry. The new
+// entry is sent without deploymentSettings, so the API fills in defaults
+// (availability/scale/trafficRegions and the org's first cloud integration as
+// the target). Existing apps are re-sent so they're preserved — the PATCH
+// endpoint replaces the apps array wholesale.
+func (ds *DeploymentService) AddAppToDeployment(organizationId, deploymentId, appId string) (*models.Deployment, error) {
+	deploymentUrl := fmt.Sprintf("%s/api/organizations/%s/deployments/%s", ds.baseUrl, organizationId, deploymentId)
+
+	getReq, err := http.NewRequest("GET", deploymentUrl, nil)
+	if err != nil {
+		return nil, err
+	}
+	getResp, err := ds.httpClient.Do(getReq)
+	if err != nil {
+		return nil, err
+	}
+	defer getResp.Body.Close()
+	if getResp.StatusCode != http.StatusOK {
+		return nil, errors.HandleHTTPError(getResp)
+	}
+	getBody, err := io.ReadAll(getResp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to read response body")
+	}
+
+	var current struct {
+		Apps []map[string]any `json:"apps"`
+	}
+	if err := json.Unmarshal(getBody, &current); err != nil {
+		return nil, errors.Wrap(err, "Failed to parse JSON response")
+	}
+
+	for _, app := range current.Apps {
+		if settings, ok := app["deploymentSettings"].(map[string]any); ok {
+			delete(settings, "projectEnvironment")
+			if dns, ok := settings["dns"].(map[string]any); ok {
+				if zoneName, _ := dns["zoneName"].(string); zoneName == "" {
+					delete(settings, "dns")
+				}
+			}
+		}
+	}
+
+	apps := append(current.Apps, map[string]any{
+		"app": map[string]any{"id": appId},
+	})
+
+	requestBody, err := json.Marshal(map[string]any{
+		"apps": apps,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to marshal request body")
+	}
+
+	req, err := http.NewRequest("PATCH", deploymentUrl, io.NopCloser(bytes.NewReader(requestBody)))
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create a new HTTP request")
+	}
+
+	resp, err := ds.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.HandleHTTPError(resp)
+	}
+
+	// The PATCH response doesn't include readiness fields (isReady,
+	// readinessIssues) — only GET does. Re-fetch so callers get a fully
+	// populated deployment.
+	return ds.GetDeployment(organizationId, deploymentId)
+}
+
 func (ds *DeploymentService) CreateEnvironmentDeployment(organizationId, projectId, projectEnvironmentId, appId, name, alternateId, description string) (*models.Deployment, error) {
 	url := fmt.Sprintf("%s/api/organizations/%s/deployments/", ds.baseUrl, organizationId)
 


### PR DESCRIPTION
add support to patch the app with defaults into the deployment when you pass the app in `apps` options, or if the app is in the .hx file with no `apps` option pass. 

https://www.loom.com/share/5d9d34c444cf4557bfe46818f3878cb6