### PR TITLE
Speed up env push and pull

### DIFF
--- a/cmd/env/pull/pull.go
+++ b/cmd/env/pull/pull.go
@@ -316,7 +316,7 @@ func (s *service) pullEnv(orgId, envName, appId string, secret models.Secret, cf
 	}
 
 	if err := os.WriteFile(envFileName, []byte(envDataDecrypted), 0600); err != nil {
-		result.err = fmt.Errorf("failed to save decrypted environment: %s, variables to file: %s", envName, envFileName)
+		result.err = fmt.Errorf("failed to save decrypted environment %s to file %s: %w", envName, envFileName, err)
 		return result
 	}
 

--- a/cmd/env/pull/pull.go
+++ b/cmd/env/pull/pull.go
@@ -237,10 +237,10 @@ type pullEnvResult struct {
 	err       error
 }
 
-func (s *service) saveDecryptedEnvIntoFile(orgId, envName, appId string, secret models.Secret, config config.Config, force bool, listedEnv *models.Env, recorder *timing.Recorder) error {
+func (s *service) saveDecryptedEnvIntoFile(orgId, envName, appId string, secret models.Secret, cfg config.Config, force bool, listedEnv *models.Env, recorder *timing.Recorder) error {
 	var result pullEnvResult
 	if err := recorder.Measure("transfer work", func() error {
-		result = s.pullEnv(orgId, envName, appId, secret, config, force, listedEnv)
+		result = s.pullEnv(orgId, envName, appId, secret, cfg, force, listedEnv)
 		return result.err
 	}); err != nil {
 		return err
@@ -261,7 +261,7 @@ func (s *service) saveDecryptedEnvIntoFile(orgId, envName, appId string, secret 
 	return nil
 }
 
-func (s *service) pullEnv(orgId, envName, appId string, secret models.Secret, config config.Config, force bool, listedEnv *models.Env) pullEnvResult {
+func (s *service) pullEnv(orgId, envName, appId string, secret models.Secret, cfg config.Config, force bool, listedEnv *models.Env) pullEnvResult {
 	result := pullEnvResult{
 		envName: envName,
 	}
@@ -284,8 +284,8 @@ func (s *service) pullEnv(orgId, envName, appId string, secret models.Secret, co
 		}
 
 		currentLocalSecret, dbSecretExists := s.db.GetSecret(database.SecretKey{
-			ProjectId: *config.ProjectId,
-			AppId:     *config.AppId,
+			ProjectId: *cfg.ProjectId,
+			AppId:     *cfg.AppId,
 			EnvName:   envName,
 		})
 		if dbSecretExists {
@@ -315,15 +315,15 @@ func (s *service) pullEnv(orgId, envName, appId string, secret models.Secret, co
 		return result
 	}
 
-	if err := os.WriteFile(envFileName, []byte(envDataDecrypted), 0644); err != nil {
+	if err := os.WriteFile(envFileName, []byte(envDataDecrypted), 0600); err != nil {
 		result.err = fmt.Errorf("failed to save decrypted environment: %s, variables to file: %s", envName, envFileName)
 		return result
 	}
 
 	result.update = database.SecretUpdate{
 		Key: database.SecretKey{
-			ProjectId: *config.ProjectId,
-			AppId:     *config.AppId,
+			ProjectId: *cfg.ProjectId,
+			AppId:     *cfg.AppId,
 			EnvName:   envName,
 		},
 		Data:    envDataDecrypted,
@@ -356,7 +356,7 @@ func (s *service) getEnvPayloadForPull(orgId, appId, envName string, secret mode
 	return s.envService.GetEnvironmentEnv(orgId, appId, envName, &secret.SecretKeyId, nil)
 }
 
-func (s *service) getAllEnvsAndDecryptIntoFiles(orgId, appId, projectId string, secret models.Secret, config config.Config, force bool, recorder *timing.Recorder) ([]string, error) {
+func (s *service) getAllEnvsAndDecryptIntoFiles(orgId, appId, projectId string, secret models.Secret, cfg config.Config, force bool, recorder *timing.Recorder) ([]string, error) {
 	var allEnvs []models.Env
 	var currentEnvironments []models.Environment
 
@@ -392,7 +392,7 @@ func (s *service) getAllEnvsAndDecryptIntoFiles(orgId, appId, projectId string, 
 
 	var results []pullEnvResult
 	if err := recorder.Measure("transfer work", func() error {
-		results = s.pullEnvsConcurrently(orgId, appId, secret, config, force, envsSansDeleted, envsByName)
+		results = s.pullEnvsConcurrently(orgId, appId, secret, cfg, force, envsSansDeleted, envsByName)
 		return nil
 	}); err != nil {
 		return nil, err
@@ -456,7 +456,7 @@ func (s *service) getAllEnvsAndDecryptIntoFiles(orgId, appId, projectId string, 
 	return pulledEnvs, nil
 }
 
-func (s *service) pullEnvsConcurrently(orgId, appId string, secret models.Secret, config config.Config, force bool, envNames []string, envsByName map[string]models.Env) []pullEnvResult {
+func (s *service) pullEnvsConcurrently(orgId, appId string, secret models.Secret, cfg config.Config, force bool, envNames []string, envsByName map[string]models.Env) []pullEnvResult {
 	results := make([]pullEnvResult, len(envNames))
 	sem := make(chan struct{}, maxConcurrentEnvOps)
 	var wg sync.WaitGroup
@@ -476,7 +476,7 @@ func (s *service) pullEnvsConcurrently(orgId, appId string, secret models.Secret
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			result := s.pullEnv(orgId, envName, appId, secret, config, force, listedEnv)
+			result := s.pullEnv(orgId, envName, appId, secret, cfg, force, listedEnv)
 			result.index = i
 			results[i] = result
 		}()

--- a/cmd/env/pull/pull.go
+++ b/cmd/env/pull/pull.go
@@ -3,12 +3,14 @@ package pull
 import (
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/Hyphen/cli/internal/config"
 	"github.com/Hyphen/cli/internal/database"
 	"github.com/Hyphen/cli/internal/env"
 	"github.com/Hyphen/cli/internal/models"
 	"github.com/Hyphen/cli/internal/secret"
+	"github.com/Hyphen/cli/internal/timing"
 	"github.com/Hyphen/cli/internal/vinz"
 	"github.com/Hyphen/cli/pkg/cprint"
 	"github.com/Hyphen/cli/pkg/errors"
@@ -24,6 +26,8 @@ var (
 	versionPtr *int = nil
 	printer    *cprint.CPrinter
 )
+
+const maxConcurrentEnvOps = 4
 
 var PullCmd = &cobra.Command{
 	Use:   "pull [environment]",
@@ -46,6 +50,7 @@ After pulling, all environment variables will be locally available and ready for
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		printer = cprint.NewCPrinter(flags.VerboseFlag)
+		versionPtr = nil
 		if version != 0 {
 			versionPtr = &version
 		}
@@ -57,13 +62,20 @@ After pulling, all environment variables will be locally available and ready for
 }
 
 func RunPull(args []string, forceFlag bool) error {
-	config, err := config.RestoreConfig()
-	if err != nil {
+	recorder := timing.NewRecorder()
+	defer recorder.Print(printer, "env pull")
+
+	var cfg config.Config
+	if err := recorder.Measure("config load", func() error {
+		var err error
+		cfg, err = config.RestoreConfig()
+		return err
+	}); err != nil {
 		return err
 	}
 
 	// Check if this is a monorepo
-	if config.IsMonorepoProject() && config.Project != nil {
+	if cfg.IsMonorepoProject() && cfg.Project != nil {
 		// Store current directory
 		currentDir, err := os.Getwd()
 		if err != nil {
@@ -71,7 +83,7 @@ func RunPull(args []string, forceFlag bool) error {
 		}
 
 		// Pull for each workspace app
-		for _, appDir := range config.Project.Apps {
+		for _, appDir := range cfg.Project.Apps {
 			if !Silent {
 				printer.Print(fmt.Sprintf("Pulling for workspace app: %s", appDir))
 			}
@@ -84,7 +96,7 @@ func RunPull(args []string, forceFlag bool) error {
 			}
 
 			// Run pull for this app
-			err = pullForApp(args, forceFlag)
+			err = pullForApp(args, forceFlag, recorder)
 			if err != nil {
 				printer.Warning(fmt.Sprintf("Failed to pull for app %s: %s", appDir, err))
 			}
@@ -100,12 +112,16 @@ func RunPull(args []string, forceFlag bool) error {
 	}
 
 	// If not a monorepo, proceed with regular pull for top-level app
-	return pullForApp(args, forceFlag)
+	return pullForApp(args, forceFlag, recorder)
 }
 
-func pullForApp(args []string, forceFlag bool) error {
-	db, err := database.Restore()
-	if err != nil {
+func pullForApp(args []string, forceFlag bool, recorder *timing.Recorder) error {
+	var db database.Database
+	if err := recorder.Measure("database load", func() error {
+		var err error
+		db, err = database.Restore()
+		return err
+	}); err != nil {
 		return err
 	}
 
@@ -136,14 +152,18 @@ func pullForApp(args []string, forceFlag bool) error {
 		envName = args[0]
 	}
 
-	secret, _, err := secret.LoadSecret(config.OrganizationId, *config.ProjectId)
-	if err != nil {
+	var secretValue models.Secret
+	if err := recorder.Measure("secret load", func() error {
+		var err error
+		secretValue, _, err = secret.LoadSecret(config.OrganizationId, *config.ProjectId)
+		return err
+	}); err != nil {
 		return err
 	}
 
 	switch envName {
 	case "": // ALL
-		pulledEnvs, err := service.getAllEnvsAndDecryptIntoFiles(orgId, appId, projectId, secret, config, forceFlag)
+		pulledEnvs, err := service.getAllEnvsAndDecryptIntoFiles(orgId, appId, projectId, secretValue, config, forceFlag, recorder)
 		if err != nil {
 			return err
 		}
@@ -153,7 +173,7 @@ func pullForApp(args []string, forceFlag bool) error {
 		}
 		return nil
 	case "default":
-		if err = service.saveDecryptedEnvIntoFile(orgId, "default", appId, secret, config, forceFlag); err != nil {
+		if err = service.saveDecryptedEnvIntoFile(orgId, "default", appId, secretValue, config, forceFlag, nil, recorder); err != nil {
 			return err
 		}
 
@@ -166,7 +186,7 @@ func pullForApp(args []string, forceFlag bool) error {
 		if err != nil {
 			return err
 		}
-		if err = service.saveDecryptedEnvIntoFile(orgId, envName, appId, secret, config, forceFlag); err != nil {
+		if err = service.saveDecryptedEnvIntoFile(orgId, envName, appId, secretValue, config, forceFlag, nil, recorder); err != nil {
 			return err
 		}
 
@@ -208,11 +228,50 @@ func (s *service) checkForEnvironment(orgId, envName, projectId string) error {
 	return nil
 }
 
-func (s *service) saveDecryptedEnvIntoFile(orgId, envName, appId string, secret models.Secret, config config.Config, force bool) error {
-	envFileName, err := env.GetFileName(envName)
-	if err != nil {
+type pullEnvResult struct {
+	index     int
+	envName   string
+	fileName  string
+	update    database.SecretUpdate
+	hasUpdate bool
+	err       error
+}
+
+func (s *service) saveDecryptedEnvIntoFile(orgId, envName, appId string, secret models.Secret, config config.Config, force bool, listedEnv *models.Env, recorder *timing.Recorder) error {
+	var result pullEnvResult
+	if err := recorder.Measure("transfer work", func() error {
+		result = s.pullEnv(orgId, envName, appId, secret, config, force, listedEnv)
+		return result.err
+	}); err != nil {
 		return err
 	}
+
+	if result.hasUpdate {
+		if err := recorder.Measure("db update", func() error {
+			return s.db.UpsertSecrets([]database.SecretUpdate{result.update})
+		}); err != nil {
+			return err
+		}
+	}
+
+	if result.fileName != "" {
+		_ = gitutil.EnsureGitignore(result.fileName)
+	}
+
+	return nil
+}
+
+func (s *service) pullEnv(orgId, envName, appId string, secret models.Secret, config config.Config, force bool, listedEnv *models.Env) pullEnvResult {
+	result := pullEnvResult{
+		envName: envName,
+	}
+
+	envFileName, err := env.GetFileName(envName)
+	if err != nil {
+		result.err = err
+		return result
+	}
+	result.fileName = envFileName
 
 	_, err = os.Stat(envFileName)
 	fileExists := !os.IsNotExist(err)
@@ -220,7 +279,8 @@ func (s *service) saveDecryptedEnvIntoFile(orgId, envName, appId string, secret 
 	if fileExists && !force {
 		currentLocal, err := env.New(envFileName)
 		if err != nil {
-			return err
+			result.err = err
+			return result
 		}
 
 		currentLocalSecret, dbSecretExists := s.db.GetSecret(database.SecretKey{
@@ -232,108 +292,210 @@ func (s *service) saveDecryptedEnvIntoFile(orgId, envName, appId string, secret 
 			actual := currentLocal.HashData()
 			expectedHash := currentLocalSecret.Hash
 			if actual != expectedHash && !force {
-				return fmt.Errorf("local \"%s\" environment has been modified. Use --force to overwrite", envName)
+				result.err = fmt.Errorf("local \"%s\" environment has been modified. Use --force to overwrite", envName)
+				return result
 			}
 		}
 	}
 
-	e, err := s.envService.GetEnvironmentEnv(orgId, appId, envName, &secret.SecretKeyId, versionPtr)
-
-	// Case 1: Error occurred and no version specified
-	if err != nil && versionPtr == nil {
-		return err
+	e, err := s.getEnvPayloadForPull(orgId, appId, envName, secret, listedEnv)
+	if err != nil {
+		result.err = err
+		return result
 	}
 
-	// Case 2: Error occurred and version specified
-	if err != nil && versionPtr != nil {
-		// Check if it's a NotFound error
-		if !errors.Is(err, errors.ErrNotFound) {
-			return err
-		}
-
-		// Handle NotFound error
-		if !Silent {
-			printer.Warning(fmt.Sprintf("No version found for environment %s. Pulling the latest version.", envName))
-		}
-
-		// Retry without version
-		e, err = s.envService.GetEnvironmentEnv(orgId, appId, envName, &secret.SecretKeyId, nil)
-		if err != nil {
-			return err
-		}
+	if e.Version == nil {
+		result.err = fmt.Errorf("remote \"%s\" environment has no version", envName)
+		return result
 	}
 
 	envDataDecrypted, err := e.DecryptData(secret)
 	if err != nil {
-		return err
+		result.err = err
+		return result
 	}
 
-	if err := s.db.UpsertSecret(
-		database.SecretKey{
+	if err := os.WriteFile(envFileName, []byte(envDataDecrypted), 0644); err != nil {
+		result.err = fmt.Errorf("failed to save decrypted environment: %s, variables to file: %s", envName, envFileName)
+		return result
+	}
+
+	result.update = database.SecretUpdate{
+		Key: database.SecretKey{
 			ProjectId: *config.ProjectId,
 			AppId:     *config.AppId,
 			EnvName:   envName,
 		},
-		envDataDecrypted, *e.Version); err != nil {
-		return err
+		Data:    envDataDecrypted,
+		Version: *e.Version,
 	}
+	result.hasUpdate = true
 
-	if _, err = e.DecryptVarsAndSaveIntoFile(envFileName, secret); err != nil {
-		return fmt.Errorf("failed to save decrypted environment: %s, variables to file: %s", envName, envFileName)
-	}
-
-	// attempt to add this to .gitignore for the user. Do not fail out if we can't
-	_ = gitutil.EnsureGitignore(envFileName)
-
-	return nil
+	return result
 }
 
-func (s *service) getAllEnvsAndDecryptIntoFiles(orgId, appId, projectId string, secret models.Secret, config config.Config, force bool) ([]string, error) {
-	// Currently, api/organizations/:orgId/dot-envs returns all stored ENV files, even if the environment has been deleted
-	allEnvs, err := s.envService.ListEnvs(orgId, appId, 100, 1)
-	if err != nil {
-		return nil, err
+func (s *service) getEnvPayloadForPull(orgId, appId, envName string, secret models.Secret, listedEnv *models.Env) (models.Env, error) {
+	if versionPtr == nil && listedEnv != nil && listedEnv.Data != "" && listedEnv.Version != nil &&
+		listedEnv.SecretKeyID != nil && *listedEnv.SecretKeyID == secret.SecretKeyId {
+		return *listedEnv, nil
 	}
 
-	// Get the current list of environments that doesn't include deleted ones
-	currentEnvironments, err := s.envService.ListEnvironments(orgId, projectId, 100, 1)
-	if err != nil {
+	e, err := s.envService.GetEnvironmentEnv(orgId, appId, envName, &secret.SecretKeyId, versionPtr)
+	if err == nil {
+		return e, nil
+	}
+
+	if versionPtr == nil || !errors.Is(err, errors.ErrNotFound) {
+		return models.Env{}, err
+	}
+
+	if !Silent {
+		printer.Warning(fmt.Sprintf("No version found for environment %s. Pulling the latest version.", envName))
+	}
+
+	return s.envService.GetEnvironmentEnv(orgId, appId, envName, &secret.SecretKeyId, nil)
+}
+
+func (s *service) getAllEnvsAndDecryptIntoFiles(orgId, appId, projectId string, secret models.Secret, config config.Config, force bool, recorder *timing.Recorder) ([]string, error) {
+	var allEnvs []models.Env
+	var currentEnvironments []models.Environment
+
+	if err := recorder.Measure("remote list", func() error {
+		var wg sync.WaitGroup
+		var allErr error
+		var currentErr error
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			// Currently, api/organizations/:orgId/dot-envs returns all stored ENV files, even if the environment has been deleted.
+			allEnvs, allErr = s.envService.ListEnvs(orgId, appId, 100, 1)
+		}()
+		go func() {
+			defer wg.Done()
+			// Get the current list of environments that doesn't include deleted ones.
+			currentEnvironments, currentErr = s.envService.ListEnvironments(orgId, projectId, 100, 1)
+		}()
+		wg.Wait()
+
+		if allErr != nil {
+			return allErr
+		}
+		return currentErr
+	}); err != nil {
 		return nil, err
 	}
 
 	// Filters out the environments that have been deleted
 	envsSansDeleted := filterEnvsByCurrentEnvironments(allEnvs, currentEnvironments)
+	envsByName := envMapByName(allEnvs)
 
-	var pulledEnvs []string
-	for _, envName := range envsSansDeleted {
-		if err := s.saveDecryptedEnvIntoFile(orgId, envName, appId, secret, config, force); err != nil {
+	var results []pullEnvResult
+	if err := recorder.Measure("transfer work", func() error {
+		results = s.pullEnvsConcurrently(orgId, appId, secret, config, force, envsSansDeleted, envsByName)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	var (
+		pulledEnvs []string
+		updates    []database.SecretUpdate
+		files      []string
+	)
+	for _, result := range results {
+		if result.err != nil {
 			if !Silent {
-				printer.Warning(fmt.Sprintf("Failed to pull environment %s: %s", envName, err))
+				printer.Warning(fmt.Sprintf("Failed to pull environment %s: %s", result.envName, result.err))
 			}
 			continue
 		}
-		pulledEnvs = append(pulledEnvs, envName)
+		pulledEnvs = append(pulledEnvs, result.envName)
+		if result.hasUpdate {
+			updates = append(updates, result.update)
+		}
+		if result.fileName != "" {
+			files = append(files, result.fileName)
+		}
+	}
 
+	if len(updates) > 0 {
+		if err := recorder.Measure("db update", func() error {
+			return s.db.UpsertSecrets(updates)
+		}); err != nil {
+			return nil, err
+		}
 	}
 
 	// Workaround for apix#1599: Create empty env files for environments that exist in
 	// ListEnvironments but not in ListEnvs (new environments with no secrets pushed yet)
 	missingEnvs := findMissingEnvironments(allEnvs, currentEnvironments)
-	for _, envName := range missingEnvs {
-		created, err := createEmptyEnvFile(envName)
-		if err != nil {
-			if !Silent {
-				printer.Warning(fmt.Sprintf("Failed to create empty environment file for %s: %s", envName, err))
+	if err := recorder.Measure("local file setup", func() error {
+		for _, file := range files {
+			_ = gitutil.EnsureGitignore(file)
+		}
+
+		for _, envName := range missingEnvs {
+			created, err := createEmptyEnvFile(envName)
+			if err != nil {
+				if !Silent {
+					printer.Warning(fmt.Sprintf("Failed to create empty environment file for %s: %s", envName, err))
+				}
+				continue
 			}
-			continue
+			if created {
+				printer.PrintVerbose(fmt.Sprintf("Creating empty .env file for missing new environment %s", envName))
+				pulledEnvs = append(pulledEnvs, envName)
+			}
 		}
-		if created {
-			printer.PrintVerbose(fmt.Sprintf("Creating empty .env file for missing new environment %s", envName))
-			pulledEnvs = append(pulledEnvs, envName)
-		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	return pulledEnvs, nil
+}
+
+func (s *service) pullEnvsConcurrently(orgId, appId string, secret models.Secret, config config.Config, force bool, envNames []string, envsByName map[string]models.Env) []pullEnvResult {
+	results := make([]pullEnvResult, len(envNames))
+	sem := make(chan struct{}, maxConcurrentEnvOps)
+	var wg sync.WaitGroup
+
+	for i, envName := range envNames {
+		i := i
+		envName := envName
+		var listedEnv *models.Env
+		if e, ok := envsByName[envName]; ok {
+			e := e
+			listedEnv = &e
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			result := s.pullEnv(orgId, envName, appId, secret, config, force, listedEnv)
+			result.index = i
+			results[i] = result
+		}()
+	}
+
+	wg.Wait()
+	return results
+}
+
+func envMapByName(allEnvs []models.Env) map[string]models.Env {
+	envsByName := make(map[string]models.Env, len(allEnvs))
+	for _, e := range allEnvs {
+		envName := "default"
+		if e.ProjectEnv != nil {
+			envName = e.ProjectEnv.AlternateID
+		}
+		envsByName[envName] = e
+	}
+	return envsByName
 }
 
 func filterEnvsByCurrentEnvironments(allEnvs []models.Env, validEnvironments []models.Environment) []string {

--- a/cmd/env/pull/pull_test.go
+++ b/cmd/env/pull/pull_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Hyphen/cli/internal/database"
 	"github.com/Hyphen/cli/internal/env"
 	"github.com/Hyphen/cli/internal/models"
+	"github.com/Hyphen/cli/internal/timing"
 	"github.com/Hyphen/cli/pkg/cprint"
 	"github.com/Hyphen/cli/pkg/flags"
 	"github.com/stretchr/testify/assert"
@@ -259,7 +260,7 @@ func TestGetAllEnvsAndDecryptIntoFiles(t *testing.T) {
 			}, nil)
 
 		secret := models.Secret{}
-		pulledEnvs, err := svc.getAllEnvsAndDecryptIntoFiles(theOrgId, theAppId, theProjectId, secret, cfg, false)
+		pulledEnvs, err := svc.getAllEnvsAndDecryptIntoFiles(theOrgId, theAppId, theProjectId, secret, cfg, false, timing.NewRecorder())
 
 		assert.NoError(t, err)
 		assert.Contains(t, pulledEnvs, "staging")
@@ -313,7 +314,7 @@ func TestGetAllEnvsAndDecryptIntoFiles(t *testing.T) {
 			Return(models.Env{}, assert.AnError)
 
 		secret := models.Secret{}
-		pulledEnvs, err := svc.getAllEnvsAndDecryptIntoFiles(theOrgId, theAppId, theProjectId, secret, cfg, false)
+		pulledEnvs, err := svc.getAllEnvsAndDecryptIntoFiles(theOrgId, theAppId, theProjectId, secret, cfg, false, timing.NewRecorder())
 
 		assert.NoError(t, err)
 		// No envs should be pulled because GetEnvironmentEnv fails
@@ -373,7 +374,7 @@ func TestGetAllEnvsAndDecryptIntoFiles(t *testing.T) {
 			Return(models.Env{}, assert.AnError)
 
 		secret := models.Secret{}
-		_, err := svc.getAllEnvsAndDecryptIntoFiles(theOrgId, theAppId, theProjectId, secret, cfg, false)
+		_, err := svc.getAllEnvsAndDecryptIntoFiles(theOrgId, theAppId, theProjectId, secret, cfg, false, timing.NewRecorder())
 
 		assert.NoError(t, err)
 

--- a/cmd/env/push/push.go
+++ b/cmd/env/push/push.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/Hyphen/cli/internal/config"
 	"github.com/Hyphen/cli/internal/database"
 	"github.com/Hyphen/cli/internal/env"
 	"github.com/Hyphen/cli/internal/models"
 	"github.com/Hyphen/cli/internal/secret"
+	"github.com/Hyphen/cli/internal/timing"
 	"github.com/Hyphen/cli/internal/vinz"
 	"github.com/Hyphen/cli/pkg/cprint"
 	"github.com/Hyphen/cli/pkg/errors"
@@ -19,6 +21,8 @@ import (
 
 var Silent bool = false
 var printer *cprint.CPrinter
+
+const maxConcurrentEnvOps = 4
 
 var PushCmd = &cobra.Command{
 	Use:   "push [environment]",
@@ -50,26 +54,49 @@ After pushing, all environment variables will be securely stored in Hyphen and a
 }
 
 func RunPush(args []string, cmd *cobra.Command) error {
-	config, err := config.RestoreConfig()
-	if err != nil {
+	recorder := timing.NewRecorder()
+	defer recorder.Print(printer, "env push")
+
+	var cfg config.Config
+	if err := recorder.Measure("config load", func() error {
+		var err error
+		cfg, err = config.RestoreConfig()
 		return err
-	}
-	secret, _, err := secret.LoadSecret(config.OrganizationId, *config.ProjectId)
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 
-	return RunPushUsingSecret(args, secret, cmd)
+	var secretValue models.Secret
+	if err := recorder.Measure("secret load", func() error {
+		var err error
+		secretValue, _, err = secret.LoadSecret(cfg.OrganizationId, *cfg.ProjectId)
+		return err
+	}); err != nil {
+		return err
+	}
+
+	return runPushUsingSecret(args, secretValue, cmd, recorder)
 }
 
 func RunPushUsingSecret(args []string, secret models.Secret, cmd *cobra.Command) error {
-	config, err := config.RestoreConfig()
-	if err != nil {
+	recorder := timing.NewRecorder()
+	defer recorder.Print(printer, "env push")
+
+	return runPushUsingSecret(args, secret, cmd, recorder)
+}
+
+func runPushUsingSecret(args []string, secret models.Secret, cmd *cobra.Command, recorder *timing.Recorder) error {
+	var cfg config.Config
+	if err := recorder.Measure("config load", func() error {
+		var err error
+		cfg, err = config.RestoreConfig()
+		return err
+	}); err != nil {
 		return err
 	}
 
 	// Check if this is a monorepo
-	if config.IsMonorepoProject() && config.Project != nil {
+	if cfg.IsMonorepoProject() && cfg.Project != nil {
 		// Store current directory
 		currentDir, err := os.Getwd()
 		if err != nil {
@@ -77,7 +104,7 @@ func RunPushUsingSecret(args []string, secret models.Secret, cmd *cobra.Command)
 		}
 
 		// Push for each workspace member
-		for _, memberDir := range config.Project.Apps {
+		for _, memberDir := range cfg.Project.Apps {
 			if !Silent {
 				printer.Print(fmt.Sprintf("Pushing for workspace member: %s", memberDir))
 			}
@@ -90,7 +117,7 @@ func RunPushUsingSecret(args []string, secret models.Secret, cmd *cobra.Command)
 			}
 
 			// Run push for this member
-			err = pushForMember(args, secret, cmd)
+			err = pushForMember(args, secret, cmd, recorder)
 			if err != nil {
 				printer.Warning(fmt.Sprintf("Failed to push for member %s: %s", memberDir, err))
 			}
@@ -106,18 +133,26 @@ func RunPushUsingSecret(args []string, secret models.Secret, cmd *cobra.Command)
 	}
 
 	// If not a monorepo, proceed with regular push
-	return pushForMember(args, secret, cmd)
+	return pushForMember(args, secret, cmd, recorder)
 }
 
 // pushForMember contains the original push logic
-func pushForMember(args []string, secret models.Secret, cmd *cobra.Command) error {
-	config, err := config.RestoreConfig()
-	if err != nil {
+func pushForMember(args []string, secret models.Secret, cmd *cobra.Command, recorder *timing.Recorder) error {
+	var cfg config.Config
+	if err := recorder.Measure("config load", func() error {
+		var err error
+		cfg, err = config.RestoreConfig()
+		return err
+	}); err != nil {
 		return err
 	}
 
-	db, err := database.Restore()
-	if err != nil {
+	var db database.Database
+	if err := recorder.Measure("database load", func() error {
+		var err error
+		db, err = database.Restore()
+		return err
+	}); err != nil {
 		return err
 	}
 
@@ -150,22 +185,40 @@ func pushForMember(args []string, secret models.Secret, cmd *cobra.Command) erro
 		}
 	}
 
-	if err := service.checkIfLocalEnvsExistAsEnvironments(envsToPush, orgId, projectId); err != nil {
+	cloudEnvs, err := service.loadPushRemoteState(envsToPush, orgId, appId, projectId, recorder)
+	if err != nil {
 		return err
 	}
 
-	for _, envName := range envsToPush {
-		e, err := env.GetLocalEncryptedEnv(envName, nil, secret)
-		if err != nil {
-			printer.Error(cmd, err)
+	var results []pushEnvResult
+	if err := recorder.Measure("transfer work", func() error {
+		results = service.pushEnvsConcurrently(orgId, appId, secret, cfg, envsToPush, cloudEnvs)
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	var updates []database.SecretUpdate
+	for _, result := range results {
+		if result.err != nil {
+			printer.Error(cmd, result.err)
 			continue
 		}
-		err, skippable := service.putEnv(orgId, envName, appId, e, secret, config, &skippedEnvs)
-		if err != nil {
-			printer.Error(cmd, err)
+		if result.skipped {
+			skippedEnvs = append(skippedEnvs, result.envName)
 			continue
-		} else if !skippable {
-			envsPushed = append(envsPushed, envName)
+		}
+		envsPushed = append(envsPushed, result.envName)
+		if result.hasUpdate {
+			updates = append(updates, result.update)
+		}
+	}
+
+	if len(updates) > 0 {
+		if err := recorder.Measure("db update", func() error {
+			return service.db.UpsertSecrets(updates)
+		}); err != nil {
+			return err
 		}
 	}
 
@@ -189,7 +242,63 @@ func newService(envService env.EnvServicer, db database.Database, vinzService vi
 	}
 }
 
-func (s *service) putEnv(orgID, envName, appID string, e models.Env, currentSecret models.Secret, config config.Config, skippedEnvs *[]string) (err error, skippable bool) {
+type pushEnvResult struct {
+	index     int
+	envName   string
+	skipped   bool
+	update    database.SecretUpdate
+	hasUpdate bool
+	err       error
+}
+
+func (s *service) pushEnvsConcurrently(orgID, appID string, currentSecret models.Secret, config config.Config, envNames []string, cloudEnvs map[string]models.Env) []pushEnvResult {
+	results := make([]pushEnvResult, len(envNames))
+	sem := make(chan struct{}, maxConcurrentEnvOps)
+	var wg sync.WaitGroup
+
+	for i, envName := range envNames {
+		i := i
+		envName := envName
+		var cloudEnv *models.Env
+		if e, ok := cloudEnvs[envName]; ok {
+			e := e
+			cloudEnv = &e
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			result := s.pushEnv(orgID, envName, appID, currentSecret, config, cloudEnv)
+			result.index = i
+			results[i] = result
+		}()
+	}
+
+	wg.Wait()
+	return results
+}
+
+func (s *service) pushEnv(orgID, envName, appID string, currentSecret models.Secret, config config.Config, cloudEnv *models.Env) pushEnvResult {
+	result := pushEnvResult{
+		envName: envName,
+	}
+
+	envFileName, err := env.GetFileName(envName)
+	if err != nil {
+		result.err = err
+		return result
+	}
+
+	localEnv, err := env.New(envFileName)
+	if err != nil {
+		result.err = err
+		return result
+	}
+	plainData := localEnv.Data
+
 	// Check local environment
 	currentLocalEnv, exists := s.db.GetSecret(database.SecretKey{
 		ProjectId: *config.ProjectId,
@@ -197,73 +306,139 @@ func (s *service) putEnv(orgID, envName, appID string, e models.Env, currentSecr
 		EnvName:   envName,
 	})
 
-	var replacingSecretKeyID int64 = 0
-	if exists {
-		err, skippable := s.validateLocalEnv(&currentLocalEnv, &e, currentSecret)
-		if err != nil {
-			return err, false
-		}
+	latestCloudEnv, cloudExists, err := s.resolveCloudEnvForPush(orgID, appID, envName, cloudEnv)
+	if err != nil {
+		result.err = err
+		return result
+	}
 
-		// get the latest secret key id for this env, if it exists
-		latestEnv, err := s.envService.GetEnvironmentEnv(orgID, appID, envName, nil, nil)
-		if err != nil {
-			// if this is not found, we'll use a nil secretKeyId - first push
-			if !errors.Is(err, errors.ErrNotFound) {
-				return err, false
-			}
-		} else {
-			replacingSecretKeyID = *latestEnv.SecretKeyID
-		}
+	replacingSecretKeyID := currentSecret.SecretKeyId
+	if cloudExists && latestCloudEnv.SecretKeyID != nil {
+		replacingSecretKeyID = *latestCloudEnv.SecretKeyID
+	}
 
-		if skippable && currentSecret.SecretKeyId == replacingSecretKeyID {
-			*skippedEnvs = append(*skippedEnvs, envName)
-			return nil, true
-		}
+	if exists && cloudExists && currentLocalEnv.Hash == localEnv.HashData() && currentSecret.SecretKeyId == replacingSecretKeyID {
+		result.skipped = true
+		return result
 	}
 
 	// try pushing version+1
-	newVersion := currentLocalEnv.Version + 1
-	e.Version = &newVersion
+	newVersion := nextEnvVersion(currentLocalEnv, exists, latestCloudEnv, cloudExists)
+	localEnv.Version = &newVersion
+	localEnv.SecretKeyID = &currentSecret.SecretKeyId
+
+	envEncryptedData, err := localEnv.EncryptData(currentSecret)
+	if err != nil {
+		result.err = err
+		return result
+	}
+	localEnv.Data = envEncryptedData
 
 	// Update cloud environment
-	if err := s.envService.PutEnvironmentEnv(orgID, appID, envName, replacingSecretKeyID, e); err != nil {
+	if err := s.envService.PutEnvironmentEnv(orgID, appID, envName, replacingSecretKeyID, localEnv); err != nil {
 		// Workaround for apix#1599: API returns 400 "secretKeyId must be >= 1" when secretKeyId is 0.
 		// This happens for new environments. Retry with the project's secret key.
 		if strings.Contains(err.Error(), "secretKeyId must be >= 1") {
-			if retryErr := s.envService.PutEnvironmentEnv(orgID, appID, envName, currentSecret.SecretKeyId, e); retryErr != nil {
-				return fmt.Errorf("failed to update cloud %s environment: %w", envName, retryErr), false
+			if retryErr := s.envService.PutEnvironmentEnv(orgID, appID, envName, currentSecret.SecretKeyId, localEnv); retryErr != nil {
+				result.err = fmt.Errorf("failed to update cloud %s environment: %w", envName, retryErr)
+				return result
 			}
 		} else {
-			return fmt.Errorf("failed to update cloud %s environment: %w", envName, err), false
+			result.err = fmt.Errorf("failed to update cloud %s environment: %w", envName, err)
+			return result
 		}
 	}
 
-	// Update local environment
-	newEnvDcrypted, err := e.DecryptData(currentSecret)
-	if err != nil {
-		return err, false
+	result.update = database.SecretUpdate{
+		Key: database.SecretKey{
+			ProjectId: *config.ProjectId,
+			AppId:     *config.AppId,
+			EnvName:   envName,
+		},
+		Data:    plainData,
+		Version: newVersion,
 	}
-	if err := s.db.UpsertSecret(database.SecretKey{
-		ProjectId: *config.ProjectId,
-		AppId:     *config.AppId,
-		EnvName:   envName,
-	}, newEnvDcrypted, currentLocalEnv.Version+1); err != nil {
-		return fmt.Errorf("failed to save local %s environment: %w", envName, err), false
-	}
+	result.hasUpdate = true
 
-	return nil, false
+	return result
 }
 
-func (s *service) validateLocalEnv(local *database.Secret, new *models.Env, secret models.Secret) (err error, skippable bool) {
-	newEnvDcrypted, err := new.DecryptData(secret)
-	if err != nil {
-		return err, false
+func (s *service) resolveCloudEnvForPush(orgID, appID, envName string, cloudEnv *models.Env) (models.Env, bool, error) {
+	if cloudEnv == nil {
+		return models.Env{}, false, nil
 	}
-	if local.Hash == models.HashData(newEnvDcrypted) {
-		return nil, true
+	if cloudEnv.SecretKeyID != nil {
+		return *cloudEnv, true, nil
 	}
 
-	return nil, false
+	latestEnv, err := s.envService.GetEnvironmentEnv(orgID, appID, envName, nil, nil)
+	if err != nil {
+		if errors.Is(err, errors.ErrNotFound) {
+			return models.Env{}, false, nil
+		}
+		return models.Env{}, false, err
+	}
+
+	return latestEnv, true, nil
+}
+
+func nextEnvVersion(local database.Secret, localExists bool, cloud models.Env, cloudExists bool) int {
+	if localExists && local.Version > 0 {
+		return local.Version + 1
+	}
+
+	if cloudExists && cloud.Version != nil && *cloud.Version > 0 {
+		return *cloud.Version + 1
+	}
+
+	return 1
+}
+
+func (s *service) loadPushRemoteState(envs []string, orgId, appId, projectId string, recorder *timing.Recorder) (map[string]models.Env, error) {
+	var environments []models.Environment
+	var cloudEnvs []models.Env
+
+	if err := recorder.Measure("remote list", func() error {
+		var wg sync.WaitGroup
+		var environmentsErr error
+		var cloudEnvsErr error
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			environments, environmentsErr = s.envService.ListEnvironments(orgId, projectId, 100, 1)
+		}()
+		go func() {
+			defer wg.Done()
+			cloudEnvs, cloudEnvsErr = s.envService.ListEnvs(orgId, appId, 100, 1)
+		}()
+		wg.Wait()
+
+		if environmentsErr != nil {
+			return environmentsErr
+		}
+		return cloudEnvsErr
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := validateLocalEnvsExistAsEnvironments(envs, environments); err != nil {
+		return nil, err
+	}
+
+	return pushEnvMapByName(cloudEnvs), nil
+}
+
+func pushEnvMapByName(allEnvs []models.Env) map[string]models.Env {
+	envsByName := make(map[string]models.Env, len(allEnvs))
+	for _, e := range allEnvs {
+		envName := "default"
+		if e.ProjectEnv != nil {
+			envName = e.ProjectEnv.AlternateID
+		}
+		envsByName[envName] = e
+	}
+	return envsByName
 }
 
 func (s *service) checkIfLocalEnvsExistAsEnvironments(envs []string, orgId, projectId string) error {
@@ -271,6 +446,10 @@ func (s *service) checkIfLocalEnvsExistAsEnvironments(envs []string, orgId, proj
 	if err != nil {
 		return err
 	}
+	return validateLocalEnvsExistAsEnvironments(envs, environments)
+}
+
+func validateLocalEnvsExistAsEnvironments(envs []string, environments []models.Environment) error {
 	mapEnvs := make(map[string]bool)
 	for _, env := range environments {
 		mapEnvs[env.AlternateID] = true

--- a/cmd/env/push/push.go
+++ b/cmd/env/push/push.go
@@ -251,7 +251,7 @@ type pushEnvResult struct {
 	err       error
 }
 
-func (s *service) pushEnvsConcurrently(orgID, appID string, currentSecret models.Secret, config config.Config, envNames []string, cloudEnvs map[string]models.Env) []pushEnvResult {
+func (s *service) pushEnvsConcurrently(orgID, appID string, currentSecret models.Secret, cfg config.Config, envNames []string, cloudEnvs map[string]models.Env) []pushEnvResult {
 	results := make([]pushEnvResult, len(envNames))
 	sem := make(chan struct{}, maxConcurrentEnvOps)
 	var wg sync.WaitGroup
@@ -271,7 +271,7 @@ func (s *service) pushEnvsConcurrently(orgID, appID string, currentSecret models
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			result := s.pushEnv(orgID, envName, appID, currentSecret, config, cloudEnv)
+			result := s.pushEnv(orgID, envName, appID, currentSecret, cfg, cloudEnv)
 			result.index = i
 			results[i] = result
 		}()
@@ -281,7 +281,7 @@ func (s *service) pushEnvsConcurrently(orgID, appID string, currentSecret models
 	return results
 }
 
-func (s *service) pushEnv(orgID, envName, appID string, currentSecret models.Secret, config config.Config, cloudEnv *models.Env) pushEnvResult {
+func (s *service) pushEnv(orgID, envName, appID string, currentSecret models.Secret, cfg config.Config, cloudEnv *models.Env) pushEnvResult {
 	result := pushEnvResult{
 		envName: envName,
 	}
@@ -301,8 +301,8 @@ func (s *service) pushEnv(orgID, envName, appID string, currentSecret models.Sec
 
 	// Check local environment
 	currentLocalEnv, exists := s.db.GetSecret(database.SecretKey{
-		ProjectId: *config.ProjectId,
-		AppId:     *config.AppId,
+		ProjectId: *cfg.ProjectId,
+		AppId:     *cfg.AppId,
 		EnvName:   envName,
 	})
 
@@ -351,8 +351,8 @@ func (s *service) pushEnv(orgID, envName, appID string, currentSecret models.Sec
 
 	result.update = database.SecretUpdate{
 		Key: database.SecretKey{
-			ProjectId: *config.ProjectId,
-			AppId:     *config.AppId,
+			ProjectId: *cfg.ProjectId,
+			AppId:     *cfg.AppId,
 			EnvName:   envName,
 		},
 		Data:    plainData,

--- a/cmd/env/push/push.go
+++ b/cmd/env/push/push.go
@@ -383,15 +383,14 @@ func (s *service) resolveCloudEnvForPush(orgID, appID, envName string, cloudEnv 
 }
 
 func nextEnvVersion(local database.Secret, localExists bool, cloud models.Env, cloudExists bool) int {
-	if localExists && local.Version > 0 {
-		return local.Version + 1
+	version := 0
+	if localExists && local.Version > version {
+		version = local.Version
 	}
-
-	if cloudExists && cloud.Version != nil && *cloud.Version > 0 {
-		return *cloud.Version + 1
+	if cloudExists && cloud.Version != nil && *cloud.Version > version {
+		version = *cloud.Version
 	}
-
-	return 1
+	return version + 1
 }
 
 func (s *service) loadPushRemoteState(envs []string, orgId, appId, projectId string, recorder *timing.Recorder) (map[string]models.Env, error) {

--- a/cmd/env/push/push_test.go
+++ b/cmd/env/push/push_test.go
@@ -169,6 +169,21 @@ func TestPushEnv(t *testing.T) {
 	})
 }
 
+func TestNextEnvVersionUsesHighestKnownVersion(t *testing.T) {
+	cloudVersion := 7
+	assert.Equal(t, 8, nextEnvVersion(database.Secret{Version: 3}, true, models.Env{Version: &cloudVersion}, true))
+
+	cloudVersion = 2
+	assert.Equal(t, 6, nextEnvVersion(database.Secret{Version: 5}, true, models.Env{Version: &cloudVersion}, true))
+
+	assert.Equal(t, 6, nextEnvVersion(database.Secret{Version: 5}, true, models.Env{}, false))
+
+	cloudVersion = 4
+	assert.Equal(t, 5, nextEnvVersion(database.Secret{}, false, models.Env{Version: &cloudVersion}, true))
+
+	assert.Equal(t, 1, nextEnvVersion(database.Secret{}, false, models.Env{}, false))
+}
+
 func withEnvFile(t *testing.T, envName, contents string) {
 	t.Helper()
 

--- a/cmd/env/push/push_test.go
+++ b/cmd/env/push/push_test.go
@@ -2,6 +2,7 @@ package push
 
 import (
 	"encoding/base64"
+	"os"
 	"testing"
 
 	"github.com/Hyphen/cli/internal/config"
@@ -21,8 +22,10 @@ func getTestSecret(secretKeyId int64) models.Secret {
 	return secret
 }
 
-func TestPutEnv(t *testing.T) {
-	t.Run("retries_with_project_secret_key_id_when_put_fails_with_secretKeyId_error", func(t *testing.T) {
+func TestPushEnv(t *testing.T) {
+	t.Run("uses_project_secret_key_id_for_first_push", func(t *testing.T) {
+		withEnvFile(t, "staging", "KEY=value")
+
 		mockEnvService := env.NewMockEnvService()
 		mockDB := new(database.MockDatabase)
 		svc := newService(mockEnvService, mockDB, nil)
@@ -38,33 +41,26 @@ func TestPutEnv(t *testing.T) {
 		}
 		secret := getTestSecret(theProjectSecretKeyId)
 
-		envData := models.Env{Data: "KEY=value"}
-		encryptedData, _ := envData.EncryptData(secret)
-		envData.Data = encryptedData
-
 		// Local env doesn't exist
 		mockDB.On("GetSecret", mock.Anything).Return(database.Secret{}, false)
 
-		// First PutEnvironmentEnv fails with the specific error
-		mockEnvService.On("PutEnvironmentEnv", "org-1", theAppId, theEnvName, int64(0), mock.Anything).
-			Return(errors.Wrapf(errors.ErrBadRequest, "bad request: querystring/secretKeyId must be >= 1")).Once()
-
-		// Retry with project secret key ID succeeds
 		mockEnvService.On("PutEnvironmentEnv", "org-1", theAppId, theEnvName, theProjectSecretKeyId, mock.Anything).
 			Return(nil).Once()
 
-		// UpsertSecret for local storage
-		mockDB.On("UpsertSecret", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		result := svc.pushEnv("org-1", theEnvName, theAppId, secret, cfg, nil)
 
-		var skippedEnvs []string
-		err, skipped := svc.putEnv("org-1", theEnvName, theAppId, envData, secret, cfg, &skippedEnvs)
-
-		assert.NoError(t, err)
-		assert.False(t, skipped)
-		mockEnvService.AssertNumberOfCalls(t, "PutEnvironmentEnv", 2)
+		assert.NoError(t, result.err)
+		assert.False(t, result.skipped)
+		assert.True(t, result.hasUpdate)
+		assert.Equal(t, "KEY=value", result.update.Data)
+		assert.Equal(t, 1, result.update.Version)
+		mockEnvService.AssertNumberOfCalls(t, "PutEnvironmentEnv", 1)
+		mockEnvService.AssertCalled(t, "PutEnvironmentEnv", "org-1", theAppId, theEnvName, theProjectSecretKeyId, mock.Anything)
 	})
 
 	t.Run("uses_cloud_secret_key_id_when_env_exists_in_cloud", func(t *testing.T) {
+		withEnvFile(t, "production", "KEY=value")
+
 		mockEnvService := env.NewMockEnvService()
 		mockDB := new(database.MockDatabase)
 		svc := newService(mockEnvService, mockDB, nil)
@@ -82,10 +78,6 @@ func TestPutEnv(t *testing.T) {
 		}
 		secret := getTestSecret(theProjectSecretKeyId)
 
-		envData := models.Env{Data: "KEY=value"}
-		encryptedData, _ := envData.EncryptData(secret)
-		envData.Data = encryptedData
-
 		// Local env exists
 		mockDB.On("GetSecret", mock.Anything).Return(database.Secret{Version: 3, Hash: "different-hash"}, true)
 
@@ -94,25 +86,23 @@ func TestPutEnv(t *testing.T) {
 			SecretKeyID: &theCloudSecretKeyId,
 			Version:     &theCloudVersion,
 		}
-		mockEnvService.On("GetEnvironmentEnv", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-			Return(cloudEnv, nil)
 
 		// Expect PutEnvironmentEnv to be called with the CLOUD's secret key ID
 		mockEnvService.On("PutEnvironmentEnv", "org-1", theAppId, theEnvName, theCloudSecretKeyId, mock.Anything).
 			Return(nil)
 
-		// UpsertSecret for local storage
-		mockDB.On("UpsertSecret", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		result := svc.pushEnv("org-1", theEnvName, theAppId, secret, cfg, &cloudEnv)
 
-		var skippedEnvs []string
-		err, skipped := svc.putEnv("org-1", theEnvName, theAppId, envData, secret, cfg, &skippedEnvs)
-
-		assert.NoError(t, err)
-		assert.False(t, skipped)
+		assert.NoError(t, result.err)
+		assert.False(t, result.skipped)
+		assert.True(t, result.hasUpdate)
 		mockEnvService.AssertCalled(t, "PutEnvironmentEnv", "org-1", theAppId, theEnvName, theCloudSecretKeyId, mock.Anything)
+		mockEnvService.AssertNotCalled(t, "GetEnvironmentEnv", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	})
 
 	t.Run("returns_error_when_put_fails_with_non_secretKeyId_error", func(t *testing.T) {
+		withEnvFile(t, "staging", "KEY=value")
+
 		mockEnvService := env.NewMockEnvService()
 		mockDB := new(database.MockDatabase)
 		svc := newService(mockEnvService, mockDB, nil)
@@ -128,23 +118,67 @@ func TestPutEnv(t *testing.T) {
 		}
 		secret := getTestSecret(theProjectSecretKeyId)
 
-		envData := models.Env{Data: "KEY=value"}
-		encryptedData, _ := envData.EncryptData(secret)
-		envData.Data = encryptedData
-
 		// Local env doesn't exist
 		mockDB.On("GetSecret", mock.Anything).Return(database.Secret{}, false)
 
 		// PutEnvironmentEnv fails with a different error
-		mockEnvService.On("PutEnvironmentEnv", "org-1", theAppId, theEnvName, int64(0), mock.Anything).
+		mockEnvService.On("PutEnvironmentEnv", "org-1", theAppId, theEnvName, theProjectSecretKeyId, mock.Anything).
 			Return(errors.Wrapf(errors.ErrUnauthorized, "unauthorized")).Once()
 
-		var skippedEnvs []string
-		err, skipped := svc.putEnv("org-1", theEnvName, theAppId, envData, secret, cfg, &skippedEnvs)
+		result := svc.pushEnv("org-1", theEnvName, theAppId, secret, cfg, nil)
 
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to update cloud staging environment")
-		assert.False(t, skipped)
+		assert.Error(t, result.err)
+		assert.Contains(t, result.err.Error(), "failed to update cloud staging environment")
+		assert.False(t, result.skipped)
 		mockEnvService.AssertNumberOfCalls(t, "PutEnvironmentEnv", 1)
 	})
+
+	t.Run("skips_unchanged_env_when_cloud_secret_matches_project_secret", func(t *testing.T) {
+		plainData := "KEY=value"
+		withEnvFile(t, "staging", plainData)
+
+		mockEnvService := env.NewMockEnvService()
+		mockDB := new(database.MockDatabase)
+		svc := newService(mockEnvService, mockDB, nil)
+
+		theProjectId := "project-123"
+		theAppId := "app-456"
+		theEnvName := "staging"
+		var theProjectSecretKeyId int64 = 99999
+		theVersion := 3
+
+		cfg := config.Config{
+			ProjectId: &theProjectId,
+			AppId:     &theAppId,
+		}
+		secret := getTestSecret(theProjectSecretKeyId)
+
+		mockDB.On("GetSecret", mock.Anything).Return(database.Secret{Version: 3, Hash: models.HashData(plainData)}, true)
+
+		cloudEnv := models.Env{
+			SecretKeyID: &theProjectSecretKeyId,
+			Version:     &theVersion,
+		}
+
+		result := svc.pushEnv("org-1", theEnvName, theAppId, secret, cfg, &cloudEnv)
+
+		assert.NoError(t, result.err)
+		assert.True(t, result.skipped)
+		assert.False(t, result.hasUpdate)
+		mockEnvService.AssertNotCalled(t, "PutEnvironmentEnv", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	})
+}
+
+func withEnvFile(t *testing.T, envName, contents string) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	originalDir, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.NoError(t, os.Chdir(tempDir))
+	t.Cleanup(func() { assert.NoError(t, os.Chdir(originalDir)) })
+
+	envFileName, err := env.GetFileName(envName)
+	assert.NoError(t, err)
+	assert.NoError(t, os.WriteFile(envFileName, []byte(contents), 0644))
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -12,6 +12,7 @@ import (
 type Database interface {
 	GetSecret(key SecretKey) (Secret, bool)
 	UpsertSecret(key SecretKey, data string, version int) error
+	UpsertSecrets(updates []SecretUpdate) error
 }
 
 type database struct {
@@ -32,6 +33,12 @@ type Secret struct {
 	Hash    string `json:"hash"`
 }
 
+type SecretUpdate struct {
+	Key     SecretKey
+	Data    string
+	Version int
+}
+
 func newSecret(data string, version int) Secret {
 	hash := sha256.New()
 
@@ -47,28 +54,46 @@ func newSecret(data string, version int) Secret {
 }
 
 func (db *database) GetSecret(key SecretKey) (Secret, bool) {
-	secret, ok := db.Secrets[key.ProjectId][key.AppId][key.EnvName]
+	project, ok := db.Secrets[key.ProjectId]
+	if !ok {
+		return Secret{}, false
+	}
+	app, ok := project[key.AppId]
+	if !ok {
+		return Secret{}, false
+	}
+	secret, ok := app[key.EnvName]
 	return secret, ok
 }
 
 // UpsertSecret saves a secret to the database.
 // Data will be hashed before saving
 func (db *database) UpsertSecret(key SecretKey, data string, version int) error {
+	return db.UpsertSecrets([]SecretUpdate{{
+		Key:     key,
+		Data:    data,
+		Version: version,
+	}})
+}
+
+func (db *database) UpsertSecrets(updates []SecretUpdate) error {
 	if db.Secrets == nil {
 		db.Secrets = make(map[string]map[string]map[string]Secret)
 	}
 
-	// Initialize the nested maps if they don't exist
-	if _, ok := db.Secrets[key.ProjectId]; !ok {
-		db.Secrets[key.ProjectId] = make(map[string]map[string]Secret)
-	}
-	if _, ok := db.Secrets[key.ProjectId][key.AppId]; !ok {
-		db.Secrets[key.ProjectId][key.AppId] = make(map[string]Secret)
-	}
+	for _, update := range updates {
+		key := update.Key
 
-	secret := newSecret(data, version)
+		// Initialize the nested maps if they don't exist
+		if _, ok := db.Secrets[key.ProjectId]; !ok {
+			db.Secrets[key.ProjectId] = make(map[string]map[string]Secret)
+		}
+		if _, ok := db.Secrets[key.ProjectId][key.AppId]; !ok {
+			db.Secrets[key.ProjectId][key.AppId] = make(map[string]Secret)
+		}
 
-	db.Secrets[key.ProjectId][key.AppId][key.EnvName] = secret
+		db.Secrets[key.ProjectId][key.AppId][key.EnvName] = newSecret(update.Data, update.Version)
+	}
 
 	return save(*db)
 }

--- a/internal/database/database_mock.go
+++ b/internal/database/database_mock.go
@@ -17,3 +17,8 @@ func (m *MockDatabase) UpsertSecret(key SecretKey, data string, version int) err
 	args := m.Called(key, data, version)
 	return args.Error(0)
 }
+
+func (m *MockDatabase) UpsertSecrets(updates []SecretUpdate) error {
+	args := m.Called(updates)
+	return args.Error(0)
+}

--- a/internal/timing/timing.go
+++ b/internal/timing/timing.go
@@ -1,0 +1,62 @@
+package timing
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Hyphen/cli/pkg/cprint"
+)
+
+type Phase struct {
+	Label    string
+	Duration time.Duration
+}
+
+type Recorder struct {
+	started time.Time
+	mu      sync.Mutex
+	phases  []Phase
+}
+
+func NewRecorder() *Recorder {
+	return &Recorder{started: time.Now()}
+}
+
+func (r *Recorder) Measure(label string, fn func() error) error {
+	started := time.Now()
+	err := fn()
+	r.Record(label, time.Since(started))
+	return err
+}
+
+func (r *Recorder) Record(label string, duration time.Duration) {
+	if r == nil {
+		return
+	}
+
+	r.mu.Lock()
+	r.phases = append(r.phases, Phase{
+		Label:    label,
+		Duration: duration,
+	})
+	r.mu.Unlock()
+}
+
+func (r *Recorder) Print(printer *cprint.CPrinter, command string) {
+	if r == nil || printer == nil {
+		return
+	}
+
+	r.mu.Lock()
+	phases := make([]Phase, len(r.phases))
+	copy(phases, r.phases)
+	total := time.Since(r.started)
+	r.mu.Unlock()
+
+	printer.PrintVerbose(fmt.Sprintf("%s timing:", command))
+	for _, phase := range phases {
+		printer.PrintVerbose(fmt.Sprintf("  %-20s %s", phase.Label, phase.Duration.Round(time.Millisecond)))
+	}
+	printer.PrintVerbose(fmt.Sprintf("  %-20s %s", "total", total.Round(time.Millisecond)))
+}

--- a/internal/timing/timing.go
+++ b/internal/timing/timing.go
@@ -24,6 +24,10 @@ func NewRecorder() *Recorder {
 }
 
 func (r *Recorder) Measure(label string, fn func() error) error {
+	if r == nil {
+		return fn()
+	}
+
 	started := time.Now()
 	err := fn()
 	r.Record(label, time.Since(started))

--- a/internal/timing/timing_test.go
+++ b/internal/timing/timing_test.go
@@ -1,0 +1,22 @@
+package timing
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecorderMeasureNilReceiver(t *testing.T) {
+	expectedErr := errors.New("boom")
+	called := false
+	var recorder *Recorder
+
+	err := recorder.Measure("phase", func() error {
+		called = true
+		return expectedErr
+	})
+
+	assert.True(t, called)
+	assert.ErrorIs(t, err, expectedErr)
+}


### PR DESCRIPTION
## Summary
- speed up `hx env pull` by parallelizing remote listing and per-environment work, reusing listed env payloads when the secret key matches, decrypting once, and batching local DB updates
- speed up `hx env push` by loading cloud env metadata once, skipping unchanged envs without per-env fetches, avoiding the first-push `secretKeyId=0` retry path, and batching local DB updates
- add verbose-only phase timing output for env push/pull via `internal/timing`

## Latest Benchmark
Benchmarked on May 7, 2026 from `D:\hyphen-tilde\piedpiper\chat` with `CI=true`, 10 runs per case, installed `hx` (`C:\Users\matth\.hyphen\hyphen.exe`) vs local `D:\hyphen\hx\hxd.exe` rebuilt from `fix/env-speed` after the follow-up review fixes.

| Command | Binary | Runs | Median | Mean | Best | Worst | Delta vs `hx` |
|---|---:|---:|---:|---:|---:|---:|---:|
| `env pull` | `hx` | 10 | 4.39s | 4.71s | 4.06s | 6.03s | baseline |
| `env pull` | `hxd` | 10 | 2.45s | 2.51s | 2.35s | 2.87s | -1.94s (-44.1%) |
| `env push` | `hx` | 10 | 3.89s | 4.18s | 3.72s | 5.85s | baseline |
| `env push` | `hxd` | 10 | 1.67s | 1.69s | 1.60s | 1.90s | -2.22s (-57.1%) |

## Validation
- `go test ./cmd/env/... ./internal/env/... ./internal/database/... ./internal/timing/...`
- `go build -o hxd.exe .`

Note: `go test ./...` was also attempted locally on Windows and still fails in existing `internal/config` auto-update tests that expect temp `HOME` behavior; the env-focused packages pass.