### PR TITLE
auto-init local app commands

### DIFF
--- a/cmd/autoinit/autoinit.go
+++ b/cmd/autoinit/autoinit.go
@@ -1,0 +1,183 @@
+package autoinit
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/Hyphen/cli/cmd/initapp"
+	"github.com/Hyphen/cli/internal/config"
+	"github.com/Hyphen/cli/internal/user"
+	"github.com/Hyphen/cli/pkg/cprint"
+	"github.com/Hyphen/cli/pkg/flags"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"golang.org/x/term"
+)
+
+const guidance = "local Hyphen app config is missing or incomplete. Run `hx init` in this directory, then rerun this command."
+
+var (
+	isStdinTerminal     = func() bool { return term.IsTerminal(int(os.Stdin.Fd())) }
+	runInitApp          = initapp.RunInitAppE
+	ensureAuthenticated = user.ErrorIfNotAuthenticated
+)
+
+func Ensure(cmd *cobra.Command, args []string) error {
+	if !NeedsLocalAppConfig(cmd, args) {
+		return nil
+	}
+
+	complete, err := HasCompleteLocalAppConfig()
+	if err != nil {
+		return fmt.Errorf("failed to read local .hx config: %w", err)
+	}
+	if complete {
+		return nil
+	}
+
+	if err := ensureAuthenticated(); err != nil {
+		return err
+	}
+
+	if shouldFailWithoutPrompt(cmd) {
+		return fmt.Errorf("%s", guidance)
+	}
+
+	if err := runInitApp(cmd, []string{}); err != nil {
+		return fmt.Errorf("auto-init failed: %w", err)
+	}
+
+	complete, err = HasCompleteLocalAppConfig()
+	if err != nil {
+		return fmt.Errorf("auto-init did not create a readable local .hx config: %w", err)
+	}
+	if !complete {
+		return fmt.Errorf("auto-init did not create complete local app config. %s", guidance)
+	}
+
+	cprint.NewCPrinter(flags.VerboseFlag).Info(fmt.Sprintf("Local Hyphen app initialized. Continuing with `%s`.", cmd.CommandPath()))
+	return nil
+}
+
+func HasCompleteLocalAppConfig() (bool, error) {
+	cfg, err := config.RestoreLocalConfig()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return strings.TrimSpace(cfg.OrganizationId) != "" &&
+		nonEmptyStringPtr(cfg.ProjectId) &&
+		nonEmptyStringPtr(cfg.AppId) &&
+		nonEmptyStringPtr(cfg.AppAlternateId), nil
+}
+
+func NeedsLocalAppConfig(cmd *cobra.Command, args []string) bool {
+	names := commandNames(cmd)
+	if len(names) == 0 {
+		return false
+	}
+
+	if matches(names, "build") ||
+		matches(names, "pull") ||
+		matches(names, "push") ||
+		matches(names, "env", "pull") ||
+		matches(names, "env", "push") ||
+		matches(names, "env", "list") ||
+		matches(names, "env", "list-versions") ||
+		matches(names, "env", "run") ||
+		matches(names, "env", "rotate-key") ||
+		matches(names, "code", "docker") {
+		return true
+	}
+
+	if matches(names, "deploy") {
+		return deployNeedsLocalAppConfig(cmd, args)
+	}
+
+	return false
+}
+
+func deployNeedsLocalAppConfig(cmd *cobra.Command, args []string) bool {
+	if len(args) == 0 {
+		return true
+	}
+
+	if stringFlag(cmd, "apps") != "" {
+		return false
+	}
+
+	return !boolFlag(cmd, "no-build")
+}
+
+func shouldFailWithoutPrompt(cmd *cobra.Command) bool {
+	return boolFlag(cmd, "no") || isJSONOutput(cmd) || !isStdinTerminal()
+}
+
+func isJSONOutput(cmd *cobra.Command) bool {
+	return strings.EqualFold(stringFlag(cmd, "output"), cprint.FormatJSON)
+}
+
+func commandNames(cmd *cobra.Command) []string {
+	var names []string
+	for current := cmd; current != nil && current.Parent() != nil; current = current.Parent() {
+		names = append([]string{current.Name()}, names...)
+	}
+	return names
+}
+
+func matches(actual []string, expected ...string) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+	for i := range expected {
+		if actual[i] != expected[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func nonEmptyStringPtr(value *string) bool {
+	return value != nil && strings.TrimSpace(*value) != ""
+}
+
+func stringFlag(cmd *cobra.Command, name string) string {
+	flag := lookupFlag(cmd, name)
+	if flag == nil {
+		return ""
+	}
+	return strings.TrimSpace(flag.Value.String())
+}
+
+func boolFlag(cmd *cobra.Command, name string) bool {
+	flag := lookupFlag(cmd, name)
+	if flag == nil {
+		return false
+	}
+	value, err := strconv.ParseBool(flag.Value.String())
+	if err != nil {
+		return false
+	}
+	return value
+}
+
+func lookupFlag(cmd *cobra.Command, name string) *pflag.Flag {
+	if cmd == nil {
+		return nil
+	}
+	if flag := cmd.Flags().Lookup(name); flag != nil {
+		return flag
+	}
+	if flag := cmd.InheritedFlags().Lookup(name); flag != nil {
+		return flag
+	}
+	if flag := cmd.PersistentFlags().Lookup(name); flag != nil {
+		return flag
+	}
+	return nil
+}

--- a/cmd/autoinit/autoinit.go
+++ b/cmd/autoinit/autoinit.go
@@ -37,12 +37,12 @@ func Ensure(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if err := ensureAuthenticated(); err != nil {
-		return err
-	}
-
 	if shouldFailWithoutPrompt(cmd) {
 		return fmt.Errorf("%s", guidance)
+	}
+
+	if err := ensureAuthenticated(); err != nil {
+		return err
 	}
 
 	if err := runInitApp(cmd, []string{}); err != nil {
@@ -115,7 +115,7 @@ func deployNeedsLocalAppConfig(cmd *cobra.Command, args []string) bool {
 }
 
 func shouldFailWithoutPrompt(cmd *cobra.Command) bool {
-	return boolFlag(cmd, "no") || isJSONOutput(cmd) || !isStdinTerminal()
+	return boolFlag(cmd, "no") || isJSONOutput(cmd) || (!isStdinTerminal() && !boolFlag(cmd, "yes"))
 }
 
 func isJSONOutput(cmd *cobra.Command) bool {

--- a/cmd/autoinit/autoinit_test.go
+++ b/cmd/autoinit/autoinit_test.go
@@ -1,0 +1,338 @@
+package autoinit
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Hyphen/cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func TestHasCompleteLocalAppConfig(t *testing.T) {
+	t.Run("returns_false_when_local_config_is_missing", func(t *testing.T) {
+		withTempDir(t)
+
+		complete, err := HasCompleteLocalAppConfig()
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if complete {
+			t.Fatalf("expected missing local config to be incomplete")
+		}
+	})
+
+	t.Run("returns_false_when_required_app_fields_are_missing", func(t *testing.T) {
+		dir := withTempDir(t)
+		writeLocalConfig(t, dir, `{
+  "organization_id": "org_test",
+  "project_id": "proj_test",
+  "app_id": "app_test"
+}`)
+
+		complete, err := HasCompleteLocalAppConfig()
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if complete {
+			t.Fatalf("expected config without app_alternate_id to be incomplete")
+		}
+	})
+
+	t.Run("returns_true_when_local_app_config_is_complete", func(t *testing.T) {
+		dir := withTempDir(t)
+		writeLocalConfig(t, dir, `{
+  "organization_id": "org_test",
+  "project_id": "proj_test",
+  "app_id": "app_test",
+  "app_alternate_id": "app-test"
+}`)
+
+		complete, err := HasCompleteLocalAppConfig()
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !complete {
+			t.Fatalf("expected complete local app config")
+		}
+	})
+}
+
+func TestNeedsLocalAppConfig(t *testing.T) {
+	testCases := []struct {
+		name     string
+		path     []string
+		args     []string
+		config   func(*cobra.Command)
+		expected bool
+	}{
+		{name: "build", path: []string{"build"}, expected: true},
+		{name: "top level pull", path: []string{"pull"}, expected: true},
+		{name: "top level push", path: []string{"push"}, expected: true},
+		{name: "env pull", path: []string{"env", "pull"}, expected: true},
+		{name: "env push", path: []string{"env", "push"}, expected: true},
+		{name: "env list", path: []string{"env", "list"}, expected: true},
+		{name: "env list versions", path: []string{"env", "list-versions"}, expected: true},
+		{name: "env run", path: []string{"env", "run"}, expected: true},
+		{name: "env rotate key", path: []string{"env", "rotate-key"}, expected: true},
+		{name: "code docker", path: []string{"code", "docker"}, expected: true},
+		{name: "project list", path: []string{"project", "list"}, expected: false},
+		{name: "init", path: []string{"init"}, expected: false},
+		{name: "deploy default", path: []string{"deploy"}, expected: true},
+		{name: "deploy explicit id builds local app", path: []string{"deploy"}, args: []string{"depl_test"}, expected: true},
+		{
+			name: "deploy explicit id with no build",
+			path: []string{"deploy"},
+			args: []string{"depl_test"},
+			config: func(cmd *cobra.Command) {
+				cmd.Flags().Bool("no-build", true, "")
+				_ = cmd.Flags().Set("no-build", "true")
+			},
+			expected: false,
+		},
+		{
+			name: "deploy explicit id with apps",
+			path: []string{"deploy"},
+			args: []string{"depl_test"},
+			config: func(cmd *cobra.Command) {
+				cmd.Flags().String("apps", "", "")
+				_ = cmd.Flags().Set("apps", "app_test")
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := commandForPath(tc.path...)
+			if tc.config != nil {
+				tc.config(cmd)
+			}
+
+			actual := NeedsLocalAppConfig(cmd, tc.args)
+
+			if actual != tc.expected {
+				t.Fatalf("expected %v, got %v", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestEnsure(t *testing.T) {
+	t.Run("does_nothing_when_command_does_not_need_local_app_config", func(t *testing.T) {
+		withTempDir(t)
+		restore := stubAutoInit(t)
+		restore.runInitApp = func(cmd *cobra.Command, args []string) error {
+			t.Fatalf("runInitApp should not be called")
+			return nil
+		}
+
+		err := Ensure(commandForPath("project", "list"), nil)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("does_nothing_when_local_app_config_is_complete", func(t *testing.T) {
+		dir := withTempDir(t)
+		writeCompleteLocalConfig(t, dir)
+		restore := stubAutoInit(t)
+		restore.runInitApp = func(cmd *cobra.Command, args []string) error {
+			t.Fatalf("runInitApp should not be called")
+			return nil
+		}
+
+		err := Ensure(commandForPath("build"), nil)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("fails_with_guidance_when_noninteractive", func(t *testing.T) {
+		withTempDir(t)
+		restore := stubAutoInit(t)
+		restore.isStdinTerminal = func() bool { return false }
+		restore.runInitApp = func(cmd *cobra.Command, args []string) error {
+			t.Fatalf("runInitApp should not be called")
+			return nil
+		}
+
+		err := Ensure(commandForPath("build"), nil)
+
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		if !strings.Contains(err.Error(), "Run `hx init`") {
+			t.Fatalf("expected guidance error, got: %v", err)
+		}
+	})
+
+	t.Run("fails_with_guidance_when_no_flag_is_set", func(t *testing.T) {
+		withTempDir(t)
+		restore := stubAutoInit(t)
+		restore.runInitApp = func(cmd *cobra.Command, args []string) error {
+			t.Fatalf("runInitApp should not be called")
+			return nil
+		}
+		cmd := commandForPath("build")
+		cmd.Flags().Bool("no", false, "")
+		_ = cmd.Flags().Set("no", "true")
+
+		err := Ensure(cmd, nil)
+
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		if !strings.Contains(err.Error(), "Run `hx init`") {
+			t.Fatalf("expected guidance error, got: %v", err)
+		}
+	})
+
+	t.Run("fails_with_guidance_for_json_output", func(t *testing.T) {
+		withTempDir(t)
+		restore := stubAutoInit(t)
+		restore.runInitApp = func(cmd *cobra.Command, args []string) error {
+			t.Fatalf("runInitApp should not be called")
+			return nil
+		}
+		cmd := commandForPath("build")
+		cmd.Flags().String("output", "", "")
+		_ = cmd.Flags().Set("output", "json")
+
+		err := Ensure(cmd, nil)
+
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		if !strings.Contains(err.Error(), "Run `hx init`") {
+			t.Fatalf("expected guidance error, got: %v", err)
+		}
+	})
+
+	t.Run("runs_init_and_revalidates_before_continuing", func(t *testing.T) {
+		dir := withTempDir(t)
+		restore := stubAutoInit(t)
+		called := false
+		restore.runInitApp = func(cmd *cobra.Command, args []string) error {
+			called = true
+			if len(args) != 0 {
+				t.Fatalf("expected auto-init to ignore original command args, got %v", args)
+			}
+			writeCompleteLocalConfig(t, dir)
+			return nil
+		}
+
+		err := Ensure(commandForPath("build"), []string{"ignored"})
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !called {
+			t.Fatalf("expected runInitApp to be called")
+		}
+	})
+
+	t.Run("returns_init_error", func(t *testing.T) {
+		withTempDir(t)
+		restore := stubAutoInit(t)
+		restore.runInitApp = func(cmd *cobra.Command, args []string) error {
+			return errors.New("init failed")
+		}
+
+		err := Ensure(commandForPath("build"), nil)
+
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		if !strings.Contains(err.Error(), "auto-init failed") {
+			t.Fatalf("expected wrapped init error, got: %v", err)
+		}
+	})
+}
+
+type autoInitStubs struct {
+	isStdinTerminal func() bool
+	runInitApp      func(*cobra.Command, []string) error
+}
+
+func stubAutoInit(t *testing.T) *autoInitStubs {
+	t.Helper()
+
+	originalIsStdinTerminal := isStdinTerminal
+	originalRunInitApp := runInitApp
+	originalEnsureAuthenticated := ensureAuthenticated
+
+	stubs := &autoInitStubs{
+		isStdinTerminal: func() bool { return true },
+		runInitApp:      func(cmd *cobra.Command, args []string) error { return nil },
+	}
+
+	isStdinTerminal = func() bool { return stubs.isStdinTerminal() }
+	runInitApp = func(cmd *cobra.Command, args []string) error { return stubs.runInitApp(cmd, args) }
+	ensureAuthenticated = func() error { return nil }
+
+	t.Cleanup(func() {
+		isStdinTerminal = originalIsStdinTerminal
+		runInitApp = originalRunInitApp
+		ensureAuthenticated = originalEnsureAuthenticated
+	})
+
+	return stubs
+}
+
+func commandForPath(parts ...string) *cobra.Command {
+	root := &cobra.Command{Use: "hyphen"}
+	current := root
+	for _, part := range parts {
+		child := &cobra.Command{Use: part}
+		current.AddCommand(child)
+		current = child
+	}
+	return current
+}
+
+func withTempDir(t *testing.T) string {
+	t.Helper()
+
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current directory: %v", err)
+	}
+
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := os.Chdir(originalDir); err != nil {
+			t.Fatalf("failed to restore current directory: %v", err)
+		}
+	})
+
+	return dir
+}
+
+func writeCompleteLocalConfig(t *testing.T, dir string) {
+	t.Helper()
+	writeLocalConfig(t, dir, `{
+  "organization_id": "org_test",
+  "project_id": "proj_test",
+  "app_id": "app_test",
+  "app_alternate_id": "app-test"
+}`)
+}
+
+func writeLocalConfig(t *testing.T, dir, contents string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, config.ManifestConfigFile), []byte(contents), 0644); err != nil {
+		t.Fatalf("failed to write local config: %v", err)
+	}
+}

--- a/cmd/autoinit/autoinit_test.go
+++ b/cmd/autoinit/autoinit_test.go
@@ -159,6 +159,10 @@ func TestEnsure(t *testing.T) {
 		withTempDir(t)
 		restore := stubAutoInit(t)
 		restore.isStdinTerminal = func() bool { return false }
+		restore.ensureAuthenticated = func() error {
+			t.Fatalf("ensureAuthenticated should not be called when auto-init cannot run")
+			return nil
+		}
 		restore.runInitApp = func(cmd *cobra.Command, args []string) error {
 			t.Fatalf("runInitApp should not be called")
 			return nil
@@ -171,6 +175,30 @@ func TestEnsure(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "Run `hx init`") {
 			t.Fatalf("expected guidance error, got: %v", err)
+		}
+	})
+
+	t.Run("runs_init_noninteractively_when_yes_flag_is_set", func(t *testing.T) {
+		dir := withTempDir(t)
+		restore := stubAutoInit(t)
+		restore.isStdinTerminal = func() bool { return false }
+		called := false
+		restore.runInitApp = func(cmd *cobra.Command, args []string) error {
+			called = true
+			writeCompleteLocalConfig(t, dir)
+			return nil
+		}
+		cmd := commandForPath("build")
+		cmd.Flags().Bool("yes", false, "")
+		_ = cmd.Flags().Set("yes", "true")
+
+		err := Ensure(cmd, nil)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !called {
+			t.Fatalf("expected runInitApp to be called")
 		}
 	})
 
@@ -258,8 +286,9 @@ func TestEnsure(t *testing.T) {
 }
 
 type autoInitStubs struct {
-	isStdinTerminal func() bool
-	runInitApp      func(*cobra.Command, []string) error
+	isStdinTerminal     func() bool
+	runInitApp          func(*cobra.Command, []string) error
+	ensureAuthenticated func() error
 }
 
 func stubAutoInit(t *testing.T) *autoInitStubs {
@@ -270,13 +299,14 @@ func stubAutoInit(t *testing.T) *autoInitStubs {
 	originalEnsureAuthenticated := ensureAuthenticated
 
 	stubs := &autoInitStubs{
-		isStdinTerminal: func() bool { return true },
-		runInitApp:      func(cmd *cobra.Command, args []string) error { return nil },
+		isStdinTerminal:     func() bool { return true },
+		runInitApp:          func(cmd *cobra.Command, args []string) error { return nil },
+		ensureAuthenticated: func() error { return nil },
 	}
 
 	isStdinTerminal = func() bool { return stubs.isStdinTerminal() }
 	runInitApp = func(cmd *cobra.Command, args []string) error { return stubs.runInitApp(cmd, args) }
-	ensureAuthenticated = func() error { return nil }
+	ensureAuthenticated = func() error { return stubs.ensureAuthenticated() }
 
 	t.Cleanup(func() {
 		isStdinTerminal = originalIsStdinTerminal

--- a/cmd/initapp/initapp.go
+++ b/cmd/initapp/initapp.go
@@ -69,12 +69,17 @@ func init() {
 }
 
 func RunInitApp(cmd *cobra.Command, args []string) {
+	if err := RunInitAppE(cmd, args); err != nil {
+		printer.Error(cmd, err)
+	}
+}
+
+func RunInitAppE(cmd *cobra.Command, args []string) error {
 	printer = cprint.NewCPrinter(flags.VerboseFlag)
 
 	if err := isValidDirectory(cmd); err != nil {
-		printer.Error(cmd, err)
 		printer.Info("Please change to a project directory and try again.")
-		return
+		return err
 	}
 
 	appService := app.NewService()
@@ -82,23 +87,21 @@ func RunInitApp(cmd *cobra.Command, args []string) {
 
 	orgID, err := flags.GetOrganizationID()
 	if err != nil {
-		printer.Error(cmd, err)
-		return
+		return err
 	}
 
 	appName, shouldContinue, err := GetAppName(cmd, args)
 	if err != nil {
-		printer.Error(cmd, err)
-		return
+		return err
 	}
 	//If the operation is canceled
 	if !shouldContinue {
-		return
+		return nil
 	}
 
 	appAlternateId := GetAppID(cmd, appName)
 	if appAlternateId == "" {
-		return
+		return nil
 	}
 
 	if config.ExistsLocal() {
@@ -109,31 +112,28 @@ func RunInitApp(cmd *cobra.Command, args []string) {
 			} else {
 				printer.Info("Operation cancelled.")
 			}
-			return
+			return nil
 		}
 	}
 
 	projectID, err := flags.GetProjectID()
 	if err != nil {
-		printer.Error(cmd, err)
-		return
+		return err
 	}
 
 	newApp, err := appService.CreateApp(orgID, projectID, appAlternateId, appName)
 	if err != nil {
 		if !errors.Is(err, errors.ErrConflict) {
-			printer.Error(cmd, err)
-			return
+			return err
 		}
 
 		existingApp, handleErr := HandleExistingApp(cmd, *appService, orgID, appAlternateId)
 		if handleErr != nil {
-			printer.Error(cmd, handleErr)
-			return
+			return handleErr
 		}
 		if existingApp == nil {
 			printer.Info("Operation cancelled.")
-			return
+			return nil
 		}
 
 		newApp = *existingApp
@@ -149,14 +149,12 @@ func RunInitApp(cmd *cobra.Command, args []string) {
 
 	err = config.InitializeConfig(mcl, config.ManifestConfigFile)
 	if err != nil {
-		printer.Error(cmd, err)
-		return
+		return err
 	}
 
 	ms, _, err := secret.LoadOrInitializeSecret(mcl.OrganizationId, *mcl.ProjectId)
 	if err != nil {
-		printer.Error(cmd, err)
-		return
+		return err
 	}
 
 	if err := gitutil.EnsureGitignore(secret.ManifestSecretFile); err != nil {
@@ -166,8 +164,7 @@ func RunInitApp(cmd *cobra.Command, args []string) {
 	// List the environments for the project
 	environments, err := envService.ListEnvironments(orgID, *mcl.ProjectId, 100, 1)
 	if err != nil {
-		printer.Error(cmd, err)
-		return
+		return err
 	}
 
 	// Create an empty .env file for each environment, push it up, and add it to .gitignore
@@ -176,28 +173,27 @@ func RunInitApp(cmd *cobra.Command, args []string) {
 		envID := e.ID
 		err = CreateAndPushEmptyEnvFile(cmd, envService, mcl, ms, orgID, newApp.ID, envID, envName)
 		if err != nil {
-			printer.Error(cmd, err)
-			return
+			return err
 		}
 	}
 
 	err = CreateAndPushEmptyEnvFile(cmd, envService, mcl, ms, orgID, newApp.ID, "default", "default")
 	if err != nil {
-		printer.Error(cmd, err)
-		return
+		return err
 	}
 
 	err = CreateGitignoredFile(cmd, ".env.local")
 	if err != nil {
-		return
+		return err
 	}
 
 	err = entrypoint.CreateEntrypoint(true)
 	if err != nil {
-		return
+		return err
 	}
 
 	PrintInitializationSummary(newApp.Name, newApp.AlternateId, newApp.ID, orgID, projectID)
+	return nil
 }
 
 func GetAppName(cmd *cobra.Command, args []string) (string, bool, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Hyphen/cli/cmd/app"
 	"github.com/Hyphen/cli/cmd/auth"
+	"github.com/Hyphen/cli/cmd/autoinit"
 	"github.com/Hyphen/cli/cmd/build"
 	"github.com/Hyphen/cli/cmd/code"
 	configcmd "github.com/Hyphen/cli/cmd/config"
@@ -37,8 +38,9 @@ The Hyphen CLI is a command-line interface for managing your Hyphen projects, en
 	// Silence usage and errors because of the use of RunE (see https://cobra.dev/docs/how-to-guides/working-with-commands/#how-to-handle-errors-with-rune)
 	SilenceUsage:  true,
 	SilenceErrors: true,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		update.RunAutoUpdate(cmd)
+		return autoinit.Ensure(cmd, args)
 	},
 }
 

--- a/internal/config/config_autoupdate_test.go
+++ b/internal/config/config_autoupdate_test.go
@@ -26,7 +26,7 @@ func TestConfigIsAutoUpdateEnabled(t *testing.T) {
 
 func TestUpsertGlobalAutoUpdateEnabled(t *testing.T) {
 	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	setTestHome(t, tempHome)
 
 	if err := UpsertGlobalAutoUpdateEnabled(false); err != nil {
 		t.Fatalf("unexpected error writing auto-update setting: %v", err)
@@ -40,7 +40,7 @@ func TestUpsertGlobalAutoUpdateEnabled(t *testing.T) {
 
 func TestUpsertGlobalConfigPreservesAutoUpdateSetting(t *testing.T) {
 	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	setTestHome(t, tempHome)
 
 	if err := UpsertGlobalAutoUpdateEnabled(false); err != nil {
 		t.Fatalf("unexpected error writing auto-update setting: %v", err)
@@ -74,4 +74,11 @@ func mustReadGlobalConfig(t *testing.T, homeDir string) Config {
 	}
 
 	return cfg
+}
+
+func setTestHome(t *testing.T, homeDir string) {
+	t.Helper()
+
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 }


### PR DESCRIPTION
## Summary

- Add an auto-init guard for commands that require local app `.hx` config.
- Invoke standard app init directly when local app config is missing, then continue the original command.
- Keep config loading scoped to validation instead of introducing shared command-wide config caching.
- Add focused auto-init tests and make auto-update config tests respect Windows `USERPROFILE`.

## Validation

- `go test ./cmd/autoinit`
- `go test ./...` with isolated temporary `HOME`/`USERPROFILE`