### PR TITLE
fix: update deployment run links

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -10,10 +10,10 @@ import (
 	"github.com/Hyphen/cli/internal/config"
 	Deployment "github.com/Hyphen/cli/internal/deployment"
 	"github.com/Hyphen/cli/internal/env"
+	hyphenapp "github.com/Hyphen/cli/internal/hyphenApp"
 	"github.com/Hyphen/cli/internal/models"
 	"github.com/Hyphen/cli/internal/projects"
 	"github.com/Hyphen/cli/internal/user"
-	"github.com/Hyphen/cli/pkg/apiconf"
 	"github.com/Hyphen/cli/pkg/cprint"
 	"github.com/Hyphen/cli/pkg/errors"
 	"github.com/Hyphen/cli/pkg/flags"
@@ -342,7 +342,7 @@ func runDeployBody(cmd *cobra.Command, args []string) (map[string]any, error) {
 		return result, fmt.Errorf("failed to create run: %w", err)
 	}
 
-	appUrl := fmt.Sprintf("%s/%s/deploy/%s/runs/%s", apiconf.GetBaseAppUrl(), orgId, selectedDeployment.ID, run.ID)
+	appUrl := hyphenapp.DeploymentRunLinkForRun(orgId, selectedDeployment, *run)
 
 	result["runId"] = run.ID
 	result["deploymentUrl"] = appUrl

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -341,8 +341,11 @@ func runDeployBody(cmd *cobra.Command, args []string) (map[string]any, error) {
 	if err != nil {
 		return result, fmt.Errorf("failed to create run: %w", err)
 	}
+	if run == nil {
+		return result, fmt.Errorf("failed to create run: empty response")
+	}
 
-	appUrl := hyphenapp.DeploymentRunLinkForRun(orgId, selectedDeployment, *run)
+	appUrl := hyphenapp.DeploymentRunLinkForRun(orgId, &selectedDeployment, run)
 
 	result["runId"] = run.ID
 	result["deploymentUrl"] = appUrl

--- a/internal/hyphenApp/hyphenApp.go
+++ b/internal/hyphenApp/hyphenApp.go
@@ -27,16 +27,24 @@ func DeploymentLink(organizationId, deploymentId string) string {
 	return fmt.Sprintf("%s/%s/deploy/%s", apiconf.GetBaseAppUrl(), organizationId, deploymentId)
 }
 
-func DeploymentRunLinkForRun(organizationId string, selectedDeployment models.Deployment, run models.DeploymentRun) string {
+func DeploymentRunLinkForRun(organizationId string, selectedDeployment *models.Deployment, run *models.DeploymentRun) string {
+	if run == nil {
+		return ""
+	}
+
 	deployment := selectedDeployment
-	if hasProjectEnvironmentRunPath(run.DeploymentSnapshot) {
-		deployment = run.DeploymentSnapshot
+	if hasProjectEnvironmentRunPath(&run.DeploymentSnapshot) {
+		deployment = &run.DeploymentSnapshot
 	}
 
 	return DeploymentRunLink(organizationId, deployment, run.ID)
 }
 
-func DeploymentRunLink(organizationId string, deployment models.Deployment, runId string) string {
+func DeploymentRunLink(organizationId string, deployment *models.Deployment, runId string) string {
+	if deployment == nil {
+		return ""
+	}
+
 	projectSegment := deploymentProjectSegment(deployment)
 	environmentSegment := deploymentEnvironmentSegment(deployment)
 
@@ -54,11 +62,15 @@ func DeploymentRunLink(organizationId string, deployment models.Deployment, runI
 	return fmt.Sprintf("%s/%s/deploy/%s/runs/%s", apiconf.GetBaseAppUrl(), organizationId, deployment.ID, runId)
 }
 
-func hasProjectEnvironmentRunPath(deployment models.Deployment) bool {
+func hasProjectEnvironmentRunPath(deployment *models.Deployment) bool {
 	return deploymentProjectSegment(deployment) != "" && deploymentEnvironmentSegment(deployment) != ""
 }
 
-func deploymentProjectSegment(deployment models.Deployment) string {
+func deploymentProjectSegment(deployment *models.Deployment) string {
+	if deployment == nil {
+		return ""
+	}
+
 	if deployment.Project.AlternateID != "" {
 		return deployment.Project.AlternateID
 	}
@@ -66,7 +78,11 @@ func deploymentProjectSegment(deployment models.Deployment) string {
 	return deployment.Project.ID
 }
 
-func deploymentEnvironmentSegment(deployment models.Deployment) string {
+func deploymentEnvironmentSegment(deployment *models.Deployment) string {
+	if deployment == nil {
+		return ""
+	}
+
 	if deployment.ProjectEnvironment.AlternateID != "" {
 		return deployment.ProjectEnvironment.AlternateID
 	}

--- a/internal/hyphenApp/hyphenApp.go
+++ b/internal/hyphenApp/hyphenApp.go
@@ -3,6 +3,7 @@ package hyphenapp
 import (
 	"fmt"
 
+	"github.com/Hyphen/cli/internal/models"
 	"github.com/Hyphen/cli/pkg/apiconf"
 )
 
@@ -26,6 +27,49 @@ func DeploymentLink(organizationId, deploymentId string) string {
 	return fmt.Sprintf("%s/%s/deploy/%s", apiconf.GetBaseAppUrl(), organizationId, deploymentId)
 }
 
-func DeploymentRunLink(organizationId, deploymentId, runId string) string {
-	return fmt.Sprintf("%s/%s/deploy/%s/runs/%s", apiconf.GetBaseAppUrl(), organizationId, deploymentId, runId)
+func DeploymentRunLinkForRun(organizationId string, selectedDeployment models.Deployment, run models.DeploymentRun) string {
+	deployment := selectedDeployment
+	if hasProjectEnvironmentRunPath(run.DeploymentSnapshot) {
+		deployment = run.DeploymentSnapshot
+	}
+
+	return DeploymentRunLink(organizationId, deployment, run.ID)
+}
+
+func DeploymentRunLink(organizationId string, deployment models.Deployment, runId string) string {
+	projectSegment := deploymentProjectSegment(deployment)
+	environmentSegment := deploymentEnvironmentSegment(deployment)
+
+	if projectSegment != "" && environmentSegment != "" {
+		return fmt.Sprintf(
+			"%s/%s/projects/%s/environments/%s/runs/%s",
+			apiconf.GetBaseAppUrl(),
+			organizationId,
+			projectSegment,
+			environmentSegment,
+			runId,
+		)
+	}
+
+	return fmt.Sprintf("%s/%s/deploy/%s/runs/%s", apiconf.GetBaseAppUrl(), organizationId, deployment.ID, runId)
+}
+
+func hasProjectEnvironmentRunPath(deployment models.Deployment) bool {
+	return deploymentProjectSegment(deployment) != "" && deploymentEnvironmentSegment(deployment) != ""
+}
+
+func deploymentProjectSegment(deployment models.Deployment) string {
+	if deployment.Project.AlternateID != "" {
+		return deployment.Project.AlternateID
+	}
+
+	return deployment.Project.ID
+}
+
+func deploymentEnvironmentSegment(deployment models.Deployment) string {
+	if deployment.ProjectEnvironment.AlternateID != "" {
+		return deployment.ProjectEnvironment.AlternateID
+	}
+
+	return deployment.ProjectEnvironment.ID
 }

--- a/internal/hyphenApp/hyphenApp_test.go
+++ b/internal/hyphenApp/hyphenApp_test.go
@@ -24,7 +24,7 @@ func TestDeploymentRunLink(t *testing.T) {
 			},
 		}
 
-		link := DeploymentRunLink("org_123", deployment, "run_123")
+		link := DeploymentRunLink("org_123", &deployment, "run_123")
 
 		assert.Equal(t, "https://app.hyphen.ai/org_123/projects/project-alt/environments/env-alt/runs/run_123", link)
 	})
@@ -40,7 +40,7 @@ func TestDeploymentRunLink(t *testing.T) {
 			},
 		}
 
-		link := DeploymentRunLink("org_123", deployment, "run_123")
+		link := DeploymentRunLink("org_123", &deployment, "run_123")
 
 		assert.Equal(t, "https://app.hyphen.ai/org_123/projects/proj_123/environments/pevr_123/runs/run_123", link)
 	})
@@ -54,7 +54,7 @@ func TestDeploymentRunLink(t *testing.T) {
 			},
 		}
 
-		link := DeploymentRunLink("org_123", deployment, "run_123")
+		link := DeploymentRunLink("org_123", &deployment, "run_123")
 
 		assert.Equal(t, "https://app.hyphen.ai/org_123/deploy/depl_123/runs/run_123", link)
 	})
@@ -68,7 +68,7 @@ func TestDeploymentRunLink(t *testing.T) {
 			},
 		}
 
-		link := DeploymentRunLink("org_123", deployment, "run_123")
+		link := DeploymentRunLink("org_123", &deployment, "run_123")
 
 		assert.Equal(t, "https://app.hyphen.ai/org_123/deploy/depl_123/runs/run_123", link)
 	})
@@ -96,7 +96,7 @@ func TestDeploymentRunLinkForRun(t *testing.T) {
 			},
 		}
 
-		link := DeploymentRunLinkForRun("org_123", selectedDeployment, run)
+		link := DeploymentRunLinkForRun("org_123", &selectedDeployment, &run)
 
 		assert.Equal(t, "https://app.hyphen.ai/org_123/projects/project-alt/environments/env-alt/runs/run_123", link)
 	})
@@ -120,10 +120,17 @@ func TestDeploymentRunLinkForRun(t *testing.T) {
 			},
 		}
 
-		link := DeploymentRunLinkForRun("org_123", selectedDeployment, run)
+		link := DeploymentRunLinkForRun("org_123", &selectedDeployment, &run)
 
 		assert.Equal(t, "https://app.hyphen.ai/org_123/projects/project-alt/environments/env-alt/runs/run_123", link)
 	})
+}
+
+func TestDeploymentRunLinkNilInputs(t *testing.T) {
+	resetAppUrlConfig(t)
+
+	assert.Empty(t, DeploymentRunLink("org_123", nil, "run_123"))
+	assert.Empty(t, DeploymentRunLinkForRun("org_123", &models.Deployment{ID: "depl_123"}, nil))
 }
 
 func resetAppUrlConfig(t *testing.T) {

--- a/internal/hyphenApp/hyphenApp_test.go
+++ b/internal/hyphenApp/hyphenApp_test.go
@@ -1,0 +1,135 @@
+package hyphenapp
+
+import (
+	"testing"
+
+	"github.com/Hyphen/cli/internal/models"
+	"github.com/Hyphen/cli/pkg/flags"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeploymentRunLink(t *testing.T) {
+	resetAppUrlConfig(t)
+
+	t.Run("uses project and environment alternate IDs", func(t *testing.T) {
+		deployment := models.Deployment{
+			ID: "depl_123",
+			Project: models.ProjectReference{
+				ID:          "proj_123",
+				AlternateID: "project-alt",
+			},
+			ProjectEnvironment: models.ProjectEnvironmentReference{
+				ID:          "pevr_123",
+				AlternateID: "env-alt",
+			},
+		}
+
+		link := DeploymentRunLink("org_123", deployment, "run_123")
+
+		assert.Equal(t, "https://app.hyphen.ai/org_123/projects/project-alt/environments/env-alt/runs/run_123", link)
+	})
+
+	t.Run("falls back to project and environment IDs", func(t *testing.T) {
+		deployment := models.Deployment{
+			ID: "depl_123",
+			Project: models.ProjectReference{
+				ID: "proj_123",
+			},
+			ProjectEnvironment: models.ProjectEnvironmentReference{
+				ID: "pevr_123",
+			},
+		}
+
+		link := DeploymentRunLink("org_123", deployment, "run_123")
+
+		assert.Equal(t, "https://app.hyphen.ai/org_123/projects/proj_123/environments/pevr_123/runs/run_123", link)
+	})
+
+	t.Run("falls back to the deployment route without project", func(t *testing.T) {
+		deployment := models.Deployment{
+			ID: "depl_123",
+			ProjectEnvironment: models.ProjectEnvironmentReference{
+				ID:          "pevr_123",
+				AlternateID: "env-alt",
+			},
+		}
+
+		link := DeploymentRunLink("org_123", deployment, "run_123")
+
+		assert.Equal(t, "https://app.hyphen.ai/org_123/deploy/depl_123/runs/run_123", link)
+	})
+
+	t.Run("falls back to the deployment route without environment", func(t *testing.T) {
+		deployment := models.Deployment{
+			ID: "depl_123",
+			Project: models.ProjectReference{
+				ID:          "proj_123",
+				AlternateID: "project-alt",
+			},
+		}
+
+		link := DeploymentRunLink("org_123", deployment, "run_123")
+
+		assert.Equal(t, "https://app.hyphen.ai/org_123/deploy/depl_123/runs/run_123", link)
+	})
+}
+
+func TestDeploymentRunLinkForRun(t *testing.T) {
+	resetAppUrlConfig(t)
+
+	t.Run("uses run deployment snapshot when selected deployment lacks route metadata", func(t *testing.T) {
+		selectedDeployment := models.Deployment{
+			ID: "depl_selected",
+		}
+		run := models.DeploymentRun{
+			ID: "run_123",
+			DeploymentSnapshot: models.Deployment{
+				ID: "depl_snapshot",
+				Project: models.ProjectReference{
+					ID:          "proj_123",
+					AlternateID: "project-alt",
+				},
+				ProjectEnvironment: models.ProjectEnvironmentReference{
+					ID:          "pevr_123",
+					AlternateID: "env-alt",
+				},
+			},
+		}
+
+		link := DeploymentRunLinkForRun("org_123", selectedDeployment, run)
+
+		assert.Equal(t, "https://app.hyphen.ai/org_123/projects/project-alt/environments/env-alt/runs/run_123", link)
+	})
+
+	t.Run("uses selected deployment when run deployment snapshot lacks route metadata", func(t *testing.T) {
+		selectedDeployment := models.Deployment{
+			ID: "depl_selected",
+			Project: models.ProjectReference{
+				ID:          "proj_123",
+				AlternateID: "project-alt",
+			},
+			ProjectEnvironment: models.ProjectEnvironmentReference{
+				ID:          "pevr_123",
+				AlternateID: "env-alt",
+			},
+		}
+		run := models.DeploymentRun{
+			ID: "run_123",
+			DeploymentSnapshot: models.Deployment{
+				ID: "depl_snapshot",
+			},
+		}
+
+		link := DeploymentRunLinkForRun("org_123", selectedDeployment, run)
+
+		assert.Equal(t, "https://app.hyphen.ai/org_123/projects/project-alt/environments/env-alt/runs/run_123", link)
+	})
+}
+
+func resetAppUrlConfig(t *testing.T) {
+	originalDevFlag := flags.DevFlag
+	flags.DevFlag = false
+	t.Cleanup(func() { flags.DevFlag = originalDevFlag })
+	t.Setenv("HYPHEN_DEV", "false")
+	t.Setenv("HYPHEN_Local", "false")
+}


### PR DESCRIPTION
related: https://github.com/Hyphen/hyphen-app/pull/1335

## Summary

- Route deployment run links through `internal/hyphenApp` instead of formatting the legacy deployment URL inline.
- Prefer project/environment run URLs when deployment metadata is available, falling back to the legacy deployment route when it is not.
- Use the run deployment snapshot when it has route metadata so links survive selected deployment payloads without project/environment details.
- Add unit coverage for alternate IDs, ID fallbacks, legacy fallbacks, and snapshot selection.


## Impact

<img width="1562" height="772" alt="Screenshot 2026-06-11 at 11 13 51 AM" src="https://github.com/user-attachments/assets/ef0367e2-bd8c-48b4-87fe-6b397055491e" />

Deployment commands now return app links that match the project/environment run route when enough metadata is available, while keeping the existing deployment URL fallback for incomplete payloads.

## Validation

- `env HOME=/private/tmp/hx-test-home GOCACHE=/private/tmp/hx-go-cache GOMODCACHE=/Users/nathanyoung/go/pkg/mod go test ./cmd/deploy ./internal/hyphenApp`

Note: `go test ./...` was also attempted. The sandboxed run first hit Go build-cache permissions, then an isolated-home run passed acceptance coverage but failed `internal/oauth` because `TestStartOAuthServer` could not start its local OAuth callback server in this environment.