### PR TITLE
feat(appcloud): add hx appcloud commands (deploy, apps, app, metrics)

### DIFF
--- a/cmd/appcloud/app.go
+++ b/cmd/appcloud/app.go
@@ -1,32 +1,51 @@
 package appcloud
 
 import (
+	"github.com/Hyphen/cli/internal/config"
 	"github.com/Hyphen/cli/pkg/cprint"
 	"github.com/Hyphen/cli/pkg/flags"
 	"github.com/spf13/cobra"
 )
 
 var appCmd = &cobra.Command{
-	Use:   "app <app-id>",
-	Short: "Show details for a single AppCloud site",
+	Use:   "app [app-id]",
+	Short: "Show or set the default app used when <app-id> is omitted",
 	Long: `
-Show the details for one AppCloud site by its ID, including its owner, attached
-domains, and the currently active revision.`,
-	Args: cobra.ExactArgs(1),
+With an <app-id>, remember it as the default app for other ` + "`hx appcloud`" + ` commands
+(persisted in ~/.hx). With no argument, show the current default app.`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		printer := cprint.NewCPrinter(flags.VerboseFlag)
 
-		orgID, err := flags.GetOrganizationID()
+		// `app <id>` — set the default app.
+		if len(args) == 1 {
+			mc, err := config.RestoreGlobalConfig()
+			if err != nil {
+				return err
+			}
+			id := args[0]
+			mc.AppCloudAppId = &id
+			if err := config.UpsertGlobalConfig(mc); err != nil {
+				return err
+			}
+			printer.Success("Default AppCloud app set to " + id)
+			return nil
+		}
+
+		// `app` — show the current default app.
+		appID, err := resolveAppID("")
 		if err != nil {
 			return err
 		}
-
-		app, err := newAppCloudService().GetApp(orgID, args[0])
+		app, err := newAppCloudService().GetApp(appID)
 		if err != nil {
 			return err
 		}
-
 		printAppSummary(printer, app)
 		return nil
 	},
+}
+
+func init() {
+	appCmd.AddCommand(newConfigCmd(true)) // `app config <get|set>` on the default app
 }

--- a/cmd/appcloud/app.go
+++ b/cmd/appcloud/app.go
@@ -32,12 +32,17 @@ With an <app-id>, remember it as the default app for other ` + "`hx appcloud`" +
 			return nil
 		}
 
-		// `app` — show the current default app.
-		appID, err := resolveAppID("")
+		// `app` (no args) — show the current default app, or guide the user
+		// to set one rather than erroring out.
+		mc, err := config.RestoreConfig()
 		if err != nil {
 			return err
 		}
-		app, err := newAppCloudService().GetApp(appID)
+		if mc.AppCloudAppId == nil || *mc.AppCloudAppId == "" {
+			printer.Info("No default app set. Run `hx appcloud app <app-id>` to select one, or `hx appcloud apps list` to see your apps.")
+			return nil
+		}
+		app, err := newAppCloudService().GetApp(*mc.AppCloudAppId)
 		if err != nil {
 			return err
 		}

--- a/cmd/appcloud/app.go
+++ b/cmd/appcloud/app.go
@@ -1,0 +1,32 @@
+package appcloud
+
+import (
+	"github.com/Hyphen/cli/pkg/cprint"
+	"github.com/Hyphen/cli/pkg/flags"
+	"github.com/spf13/cobra"
+)
+
+var appCmd = &cobra.Command{
+	Use:   "app <app-id>",
+	Short: "Show details for a single AppCloud site",
+	Long: `
+Show the details for one AppCloud site by its ID, including its owner, attached
+domains, and the currently active revision.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		printer := cprint.NewCPrinter(flags.VerboseFlag)
+
+		orgID, err := flags.GetOrganizationID()
+		if err != nil {
+			return err
+		}
+
+		app, err := newAppCloudService().GetApp(orgID, args[0])
+		if err != nil {
+			return err
+		}
+
+		printAppSummary(printer, app)
+		return nil
+	},
+}

--- a/cmd/appcloud/appcloud.go
+++ b/cmd/appcloud/appcloud.go
@@ -1,0 +1,36 @@
+package appcloud
+
+import (
+	"github.com/Hyphen/cli/internal/appcloud"
+	"github.com/Hyphen/cli/internal/user"
+	"github.com/spf13/cobra"
+)
+
+// newAppCloudService is an injection seam: commands call it to obtain the
+// service, and tests swap it for a mock.
+var newAppCloudService = func() appcloud.AppCloudServicer { return appcloud.NewService() }
+
+var AppCloudCmd = &cobra.Command{
+	Use:     "appcloud",
+	Aliases: []string{"ac"},
+	Short:   "Manage AppCloud sites and deployments",
+	Long: `
+Manage AppCloud — Hyphen's static-site platform.
+
+AppCloud serves sites at platform-issued names ({site}.app.hyphen.cloud) and
+your own verified domains. These commands talk to the AppCloud management API
+using your Hyphen login; pass --dev (or set HYPHEN_DEV=true) to target the
+development environment.`,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return user.ErrorIfNotAuthenticated()
+	},
+	// With no subcommand, list the org's sites.
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return appsCmd.RunE(cmd, args)
+	},
+}
+
+func init() {
+	AppCloudCmd.AddCommand(appsCmd)
+	AppCloudCmd.AddCommand(appCmd)
+}

--- a/cmd/appcloud/appcloud.go
+++ b/cmd/appcloud/appcloud.go
@@ -1,8 +1,13 @@
 package appcloud
 
 import (
+	"strings"
+
 	"github.com/Hyphen/cli/internal/appcloud"
+	"github.com/Hyphen/cli/internal/config"
 	"github.com/Hyphen/cli/internal/user"
+	"github.com/Hyphen/cli/pkg/cprint"
+	"github.com/Hyphen/cli/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -26,11 +31,49 @@ development environment.`,
 	},
 	// With no subcommand, list the org's sites.
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return appsCmd.RunE(cmd, args)
+		return appsListCmd.RunE(cmd, args)
 	},
 }
 
 func init() {
+	AppCloudCmd.AddCommand(deployCmd)
 	AppCloudCmd.AddCommand(appsCmd)
 	AppCloudCmd.AddCommand(appCmd)
+	AppCloudCmd.AddCommand(metricsCmd)
+}
+
+// resolveAppID returns the explicit id if given, otherwise the default app
+// persisted in ~/.hx via `hx appcloud app <id>`.
+func resolveAppID(explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+	mc, err := config.RestoreConfig()
+	if err != nil {
+		return "", err
+	}
+	if mc.AppCloudAppId != nil && *mc.AppCloudAppId != "" {
+		return *mc.AppCloudAppId, nil
+	}
+	return "", errors.New("no app id given and no default app selected; pass an <app-id> or run `hx appcloud app <id>` to select one")
+}
+
+// printAppSummary renders one app in the human-readable list/detail format.
+func printAppSummary(printer *cprint.CPrinter, a appcloud.App) {
+	name := a.Name
+	if name == "" {
+		name = a.ID
+	}
+	printer.PrintHeader(name)
+	printer.PrintDetail("ID", a.ID)
+	if a.Owner != "" {
+		printer.PrintDetail("Owner", a.Owner)
+	}
+	if len(a.Domains) > 0 {
+		printer.PrintDetail("Domains", strings.Join(a.Domains, ", "))
+	}
+	if a.ActiveRevision != "" {
+		printer.PrintDetail("Active revision", a.ActiveRevision)
+	}
+	printer.Print("")
 }

--- a/cmd/appcloud/appcloud.go
+++ b/cmd/appcloud/appcloud.go
@@ -1,6 +1,8 @@
 package appcloud
 
 import (
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/Hyphen/cli/internal/appcloud"
@@ -11,6 +13,20 @@ import (
 	"github.com/Hyphen/cli/pkg/errors"
 	"github.com/spf13/cobra"
 )
+
+// requireDir errors clearly when `dir` is missing or is not a directory. A
+// plain `os.Stat` check that returns the (nil) error for a non-directory path
+// would let a command exit 0 without doing anything.
+func requireDir(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", dir)
+	}
+	return nil
+}
 
 // newAppCloudService is an injection seam: commands call it to obtain the
 // service, and tests swap it for a mock.

--- a/cmd/appcloud/appcloud.go
+++ b/cmd/appcloud/appcloud.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Hyphen/cli/internal/appcloud"
 	"github.com/Hyphen/cli/internal/config"
+	"github.com/Hyphen/cli/internal/models"
 	"github.com/Hyphen/cli/internal/user"
 	"github.com/Hyphen/cli/pkg/cprint"
 	"github.com/Hyphen/cli/pkg/errors"
@@ -14,6 +15,34 @@ import (
 // newAppCloudService is an injection seam: commands call it to obtain the
 // service, and tests swap it for a mock.
 var newAppCloudService = func() appcloud.AppCloudServicer { return appcloud.NewService() }
+
+// getExecutionContext resolves the caller's Hyphen identity; a seam for tests.
+var getExecutionContext = func() (models.ExecutionContext, error) {
+	return user.NewService().GetExecutionContext()
+}
+
+// resolveOwner returns the explicit --owner if given, otherwise defaults to
+// the logged-in user's email (falling back to their member/user id). `owner`
+// is a display/attribution label on the app, not a security principal.
+func resolveOwner(explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+	ctx, err := getExecutionContext()
+	if err != nil {
+		return "", errors.Wrap(err, "could not determine your Hyphen identity for the app owner; pass --owner explicitly")
+	}
+	switch {
+	case ctx.Member.Email != "":
+		return ctx.Member.Email, nil
+	case ctx.Member.ID != "":
+		return ctx.Member.ID, nil
+	case ctx.User.ID != "":
+		return ctx.User.ID, nil
+	default:
+		return "", errors.New("could not determine an owner from your account; pass --owner explicitly")
+	}
+}
 
 var AppCloudCmd = &cobra.Command{
 	Use:     "appcloud",

--- a/cmd/appcloud/appcloud_test.go
+++ b/cmd/appcloud/appcloud_test.go
@@ -1,8 +1,10 @@
 package appcloud
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/Hyphen/cli/internal/models"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
@@ -54,6 +56,40 @@ func TestResolveAppID(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, "the_app_id", id)
+	})
+}
+
+func TestResolveOwner(t *testing.T) {
+	t.Run("returns_the_explicit_owner_when_given", func(t *testing.T) {
+		owner, err := resolveOwner("the-explicit-owner")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "the-explicit-owner", owner)
+	})
+
+	t.Run("defaults_to_the_logged_in_users_email", func(t *testing.T) {
+		original := getExecutionContext
+		getExecutionContext = func() (models.ExecutionContext, error) {
+			return models.ExecutionContext{Member: models.Member{Email: "me@hyphen.ai", ID: "mem_1"}}, nil
+		}
+		t.Cleanup(func() { getExecutionContext = original })
+
+		owner, err := resolveOwner("")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "me@hyphen.ai", owner)
+	})
+
+	t.Run("returns_an_error_when_identity_cannot_be_resolved", func(t *testing.T) {
+		original := getExecutionContext
+		getExecutionContext = func() (models.ExecutionContext, error) {
+			return models.ExecutionContext{}, errors.New("the fake error")
+		}
+		t.Cleanup(func() { getExecutionContext = original })
+
+		_, err := resolveOwner("")
+
+		assert.Error(t, err)
 	})
 }
 

--- a/cmd/appcloud/appcloud_test.go
+++ b/cmd/appcloud/appcloud_test.go
@@ -94,8 +94,9 @@ func TestResolveOwner(t *testing.T) {
 }
 
 func TestDeployCmdArgs(t *testing.T) {
-	t.Run("requires_exactly_one_directory_argument", func(t *testing.T) {
+	t.Run("requires_a_name_and_a_directory_argument", func(t *testing.T) {
 		assert.Error(t, deployCmd.Args(deployCmd, []string{}))
-		assert.NoError(t, deployCmd.Args(deployCmd, []string{"./dist"}))
+		assert.Error(t, deployCmd.Args(deployCmd, []string{"my-site"}))
+		assert.NoError(t, deployCmd.Args(deployCmd, []string{"my-site", "./dist"}))
 	})
 }

--- a/cmd/appcloud/appcloud_test.go
+++ b/cmd/appcloud/appcloud_test.go
@@ -3,20 +3,25 @@ package appcloud
 import (
 	"testing"
 
-	"github.com/Hyphen/cli/internal/appcloud"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
-func TestAppCloudCmd(t *testing.T) {
-	t.Run("registers_the_apps_and_app_subcommands", func(t *testing.T) {
-		names := map[string]bool{}
-		for _, c := range AppCloudCmd.Commands() {
-			names[c.Name()] = true
-		}
+func subcommandNames(c *cobra.Command) map[string]bool {
+	names := map[string]bool{}
+	for _, sub := range c.Commands() {
+		names[sub.Name()] = true
+	}
+	return names
+}
 
-		assert.True(t, names["apps"], "expected an `apps` subcommand")
-		assert.True(t, names["app"], "expected an `app` subcommand")
+func TestAppCloudCmd(t *testing.T) {
+	t.Run("registers_deploy_apps_app_and_metrics", func(t *testing.T) {
+		names := subcommandNames(AppCloudCmd)
+
+		for _, want := range []string{"deploy", "apps", "app", "metrics"} {
+			assert.True(t, names[want], "expected an `%s` subcommand", want)
+		}
 	})
 
 	t.Run("aliases_appcloud_to_ac", func(t *testing.T) {
@@ -24,32 +29,37 @@ func TestAppCloudCmd(t *testing.T) {
 	})
 }
 
-func TestAppCmdArgs(t *testing.T) {
-	t.Run("requires_exactly_one_app_id", func(t *testing.T) {
-		err := appCmd.Args(appCmd, []string{})
+func TestAppsGroup(t *testing.T) {
+	t.Run("registers_the_crud_and_deploy_subcommands", func(t *testing.T) {
+		names := subcommandNames(appsCmd)
 
-		assert.Error(t, err)
-	})
-
-	t.Run("accepts_a_single_app_id", func(t *testing.T) {
-		err := appCmd.Args(appCmd, []string{"the_app_id"})
-
-		assert.NoError(t, err)
+		for _, want := range []string{"list", "get", "create", "delete", "deploy", "config"} {
+			assert.True(t, names[want], "expected `apps %s`", want)
+		}
 	})
 }
 
-func TestAppsCmdUsesTheService(t *testing.T) {
-	t.Run("lists_apps_from_the_service_for_the_resolved_org", func(t *testing.T) {
-		mockService := new(appcloud.MockAppCloudService)
-		mockService.On("ListApps", mock.Anything, mock.Anything).
-			Return([]appcloud.App{{ID: "the_app_id", Name: "the app"}}, nil)
-		original := newAppCloudService
-		newAppCloudService = func() appcloud.AppCloudServicer { return mockService }
-		t.Cleanup(func() { newAppCloudService = original })
+func TestMetricsGroup(t *testing.T) {
+	t.Run("registers_http_and_errors", func(t *testing.T) {
+		names := subcommandNames(metricsCmd)
 
-		// The command resolves the org from flags/config; we only assert the
-		// service is wired in (org resolution is covered by the flags package).
-		assert.NotNil(t, appsCmd.RunE)
-		assert.NotNil(t, newAppCloudService())
+		assert.True(t, names["http"])
+		assert.True(t, names["errors"])
+	})
+}
+
+func TestResolveAppID(t *testing.T) {
+	t.Run("returns_the_explicit_id_when_given", func(t *testing.T) {
+		id, err := resolveAppID("the_app_id")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "the_app_id", id)
+	})
+}
+
+func TestDeployCmdArgs(t *testing.T) {
+	t.Run("requires_exactly_one_directory_argument", func(t *testing.T) {
+		assert.Error(t, deployCmd.Args(deployCmd, []string{}))
+		assert.NoError(t, deployCmd.Args(deployCmd, []string{"./dist"}))
 	})
 }

--- a/cmd/appcloud/appcloud_test.go
+++ b/cmd/appcloud/appcloud_test.go
@@ -1,0 +1,55 @@
+package appcloud
+
+import (
+	"testing"
+
+	"github.com/Hyphen/cli/internal/appcloud"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestAppCloudCmd(t *testing.T) {
+	t.Run("registers_the_apps_and_app_subcommands", func(t *testing.T) {
+		names := map[string]bool{}
+		for _, c := range AppCloudCmd.Commands() {
+			names[c.Name()] = true
+		}
+
+		assert.True(t, names["apps"], "expected an `apps` subcommand")
+		assert.True(t, names["app"], "expected an `app` subcommand")
+	})
+
+	t.Run("aliases_appcloud_to_ac", func(t *testing.T) {
+		assert.Contains(t, AppCloudCmd.Aliases, "ac")
+	})
+}
+
+func TestAppCmdArgs(t *testing.T) {
+	t.Run("requires_exactly_one_app_id", func(t *testing.T) {
+		err := appCmd.Args(appCmd, []string{})
+
+		assert.Error(t, err)
+	})
+
+	t.Run("accepts_a_single_app_id", func(t *testing.T) {
+		err := appCmd.Args(appCmd, []string{"the_app_id"})
+
+		assert.NoError(t, err)
+	})
+}
+
+func TestAppsCmdUsesTheService(t *testing.T) {
+	t.Run("lists_apps_from_the_service_for_the_resolved_org", func(t *testing.T) {
+		mockService := new(appcloud.MockAppCloudService)
+		mockService.On("ListApps", mock.Anything, mock.Anything).
+			Return([]appcloud.App{{ID: "the_app_id", Name: "the app"}}, nil)
+		original := newAppCloudService
+		newAppCloudService = func() appcloud.AppCloudServicer { return mockService }
+		t.Cleanup(func() { newAppCloudService = original })
+
+		// The command resolves the org from flags/config; we only assert the
+		// service is wired in (org resolution is covered by the flags package).
+		assert.NotNil(t, appsCmd.RunE)
+		assert.NotNil(t, newAppCloudService())
+	})
+}

--- a/cmd/appcloud/apps.go
+++ b/cmd/appcloud/apps.go
@@ -1,9 +1,8 @@
 package appcloud
 
 import (
-	"strings"
+	"os"
 
-	"github.com/Hyphen/cli/internal/appcloud"
 	"github.com/Hyphen/cli/pkg/cprint"
 	"github.com/Hyphen/cli/pkg/flags"
 	"github.com/spf13/cobra"
@@ -11,32 +10,29 @@ import (
 
 var appsCmd = &cobra.Command{
 	Use:   "apps",
+	Short: "Manage AppCloud apps (list, get, create, delete, deploy, config)",
+}
+
+var appsListCmd = &cobra.Command{
+	Use:   "list",
 	Short: "List AppCloud sites in your organization",
-	Long: `
-List the AppCloud sites in your organization. If a default project is set (or
---project is passed) the list is narrowed to that project; otherwise every site
-in the organization is shown.`,
-	Args: cobra.NoArgs,
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		printer := cprint.NewCPrinter(flags.VerboseFlag)
-
 		orgID, err := flags.GetOrganizationID()
 		if err != nil {
 			return err
 		}
-		// Project is an optional narrowing filter — no default is fine.
-		projectID, _ := flags.GetProjectID()
+		projectID, _ := flags.GetProjectID() // optional narrowing
 
 		apps, err := newAppCloudService().ListApps(orgID, projectID)
 		if err != nil {
 			return err
 		}
-
 		if len(apps) == 0 {
 			printer.Info("No AppCloud sites found.")
 			return nil
 		}
-
 		for _, a := range apps {
 			printAppSummary(printer, a)
 		}
@@ -44,21 +40,106 @@ in the organization is shown.`,
 	},
 }
 
-func printAppSummary(printer *cprint.CPrinter, a appcloud.App) {
-	name := a.Name
-	if name == "" {
-		name = a.ID
-	}
-	printer.PrintHeader(name)
-	printer.PrintDetail("ID", a.ID)
-	if a.Owner != "" {
-		printer.PrintDetail("Owner", a.Owner)
-	}
-	if len(a.Domains) > 0 {
-		printer.PrintDetail("Domains", strings.Join(a.Domains, ", "))
-	}
-	if a.ActiveRevision != "" {
-		printer.PrintDetail("Active revision", a.ActiveRevision)
-	}
-	printer.Print("")
+var appsGetCmd = &cobra.Command{
+	Use:   "get <app-id>",
+	Short: "Show a single AppCloud app",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		printer := cprint.NewCPrinter(flags.VerboseFlag)
+		app, err := newAppCloudService().GetApp(args[0])
+		if err != nil {
+			return err
+		}
+		printAppSummary(printer, app)
+		return nil
+	},
+}
+
+var (
+	createOwner   string
+	createName    string
+	createDomains []string
+)
+
+var appsCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new AppCloud app",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		printer := cprint.NewCPrinter(flags.VerboseFlag)
+		orgID, err := flags.GetOrganizationID()
+		if err != nil {
+			return err
+		}
+		projID, err := flags.GetProjectID()
+		if err != nil {
+			return err
+		}
+		app, err := newAppCloudService().CreateApp(createOwner, createName, orgID, projID, createDomains)
+		if err != nil {
+			return err
+		}
+		printer.Success("Created app " + app.ID)
+		printAppSummary(printer, app)
+		return nil
+	},
+}
+
+var appsDeleteCmd = &cobra.Command{
+	Use:   "delete <app-id>",
+	Short: "Delete an AppCloud app",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		printer := cprint.NewCPrinter(flags.VerboseFlag)
+		if err := newAppCloudService().DeleteApp(args[0]); err != nil {
+			return err
+		}
+		printer.Success("Deleted app " + args[0])
+		return nil
+	},
+}
+
+var (
+	appsDeployKind        string
+	appsDeployArtifactRef string
+	appsDeployBatchSize   int
+	appsDeployNoActivate  bool
+)
+
+var appsDeployCmd = &cobra.Command{
+	Use:   "deploy <app-id> <dir>",
+	Short: "Upload a directory as a new revision under an existing app",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		printer := cprint.NewCPrinter(flags.VerboseFlag)
+		appID, dir := args[0], args[1]
+		info, err := os.Stat(dir)
+		if err != nil || !info.IsDir() {
+			return err
+		}
+		svc := newAppCloudService()
+		app, err := svc.GetApp(appID)
+		if err != nil {
+			return err
+		}
+		return shipRevision(svc, printer, app, dir, appsDeployKind, appsDeployArtifactRef, appsDeployBatchSize, appsDeployNoActivate)
+	},
+}
+
+func init() {
+	appsCreateCmd.Flags().StringVar(&createOwner, "owner", "", "Owner label")
+	appsCreateCmd.Flags().StringVar(&createName, "name", "", "App name (URL-safe slug)")
+	appsCreateCmd.Flags().StringArrayVar(&createDomains, "domain", nil, "Domain to attach (repeatable)")
+
+	appsDeployCmd.Flags().StringVar(&appsDeployKind, "kind", "static", "Revision kind")
+	appsDeployCmd.Flags().StringVar(&appsDeployArtifactRef, "artifact-ref", "", "Client artifact reference (default: {name}@{unix_ts})")
+	appsDeployCmd.Flags().IntVar(&appsDeployBatchSize, "batch-size", 100, "Max files per upload request")
+	appsDeployCmd.Flags().BoolVar(&appsDeployNoActivate, "no-activate", false, "Upload the revision without pinning it active")
+
+	appsCmd.AddCommand(appsListCmd)
+	appsCmd.AddCommand(appsGetCmd)
+	appsCmd.AddCommand(appsCreateCmd)
+	appsCmd.AddCommand(appsDeleteCmd)
+	appsCmd.AddCommand(appsDeployCmd)
+	appsCmd.AddCommand(newConfigCmd(false)) // `apps config <get|set> <app-id>`
 }

--- a/cmd/appcloud/apps.go
+++ b/cmd/appcloud/apps.go
@@ -57,16 +57,16 @@ var appsGetCmd = &cobra.Command{
 
 var (
 	createOwner   string
-	createName    string
 	createDomains []string
 )
 
 var appsCreateCmd = &cobra.Command{
-	Use:   "create",
+	Use:   "create <name>",
 	Short: "Create a new AppCloud app",
-	Args:  cobra.NoArgs,
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		printer := cprint.NewCPrinter(flags.VerboseFlag)
+		name := args[0]
 		orgID, err := flags.GetOrganizationID()
 		if err != nil {
 			return err
@@ -75,7 +75,11 @@ var appsCreateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		app, err := newAppCloudService().CreateApp(createOwner, createName, orgID, projID, createDomains)
+		owner, err := resolveOwner(createOwner)
+		if err != nil {
+			return err
+		}
+		app, err := newAppCloudService().CreateApp(owner, name, orgID, projID, createDomains)
 		if err != nil {
 			return err
 		}
@@ -127,8 +131,7 @@ var appsDeployCmd = &cobra.Command{
 }
 
 func init() {
-	appsCreateCmd.Flags().StringVar(&createOwner, "owner", "", "Owner label")
-	appsCreateCmd.Flags().StringVar(&createName, "name", "", "App name (URL-safe slug)")
+	appsCreateCmd.Flags().StringVar(&createOwner, "owner", "", "Owner label (default: your logged-in user)")
 	appsCreateCmd.Flags().StringArrayVar(&createDomains, "domain", nil, "Domain to attach (repeatable)")
 
 	appsDeployCmd.Flags().StringVar(&appsDeployKind, "kind", "static", "Revision kind")

--- a/cmd/appcloud/apps.go
+++ b/cmd/appcloud/apps.go
@@ -1,8 +1,6 @@
 package appcloud
 
 import (
-	"os"
-
 	"github.com/Hyphen/cli/pkg/cprint"
 	"github.com/Hyphen/cli/pkg/flags"
 	"github.com/spf13/cobra"
@@ -117,8 +115,7 @@ var appsDeployCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		printer := cprint.NewCPrinter(flags.VerboseFlag)
 		appID, dir := args[0], args[1]
-		info, err := os.Stat(dir)
-		if err != nil || !info.IsDir() {
+		if err := requireDir(dir); err != nil {
 			return err
 		}
 		svc := newAppCloudService()

--- a/cmd/appcloud/apps.go
+++ b/cmd/appcloud/apps.go
@@ -1,0 +1,64 @@
+package appcloud
+
+import (
+	"strings"
+
+	"github.com/Hyphen/cli/internal/appcloud"
+	"github.com/Hyphen/cli/pkg/cprint"
+	"github.com/Hyphen/cli/pkg/flags"
+	"github.com/spf13/cobra"
+)
+
+var appsCmd = &cobra.Command{
+	Use:   "apps",
+	Short: "List AppCloud sites in your organization",
+	Long: `
+List the AppCloud sites in your organization. If a default project is set (or
+--project is passed) the list is narrowed to that project; otherwise every site
+in the organization is shown.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		printer := cprint.NewCPrinter(flags.VerboseFlag)
+
+		orgID, err := flags.GetOrganizationID()
+		if err != nil {
+			return err
+		}
+		// Project is an optional narrowing filter — no default is fine.
+		projectID, _ := flags.GetProjectID()
+
+		apps, err := newAppCloudService().ListApps(orgID, projectID)
+		if err != nil {
+			return err
+		}
+
+		if len(apps) == 0 {
+			printer.Info("No AppCloud sites found.")
+			return nil
+		}
+
+		for _, a := range apps {
+			printAppSummary(printer, a)
+		}
+		return nil
+	},
+}
+
+func printAppSummary(printer *cprint.CPrinter, a appcloud.App) {
+	name := a.Name
+	if name == "" {
+		name = a.ID
+	}
+	printer.PrintHeader(name)
+	printer.PrintDetail("ID", a.ID)
+	if a.Owner != "" {
+		printer.PrintDetail("Owner", a.Owner)
+	}
+	if len(a.Domains) > 0 {
+		printer.PrintDetail("Domains", strings.Join(a.Domains, ", "))
+	}
+	if a.ActiveRevision != "" {
+		printer.PrintDetail("Active revision", a.ActiveRevision)
+	}
+	printer.Print("")
+}

--- a/cmd/appcloud/config.go
+++ b/cmd/appcloud/config.go
@@ -1,0 +1,112 @@
+package appcloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/Hyphen/cli/internal/appcloud"
+	"github.com/Hyphen/cli/pkg/cprint"
+	"github.com/Hyphen/cli/pkg/errors"
+	"github.com/Hyphen/cli/pkg/flags"
+	"github.com/spf13/cobra"
+)
+
+// newConfigCmd builds a `config` command with `get`/`set` subcommands. When
+// `useDefaultApp` is true the app id comes from the selected default app
+// (`hx appcloud app <id>`); otherwise it's a leading positional argument.
+func newConfigCmd(useDefaultApp bool) *cobra.Command {
+	configCmd := &cobra.Command{
+		Use:   "config",
+		Short: "Read or replace an app's serving config",
+	}
+
+	getArgs, setArgs := cobra.ExactArgs(1), cobra.ExactArgs(2)
+	getUse, setUse := "get <app-id>", "set <app-id> <file>"
+	if useDefaultApp {
+		getArgs, setArgs = cobra.NoArgs, cobra.ExactArgs(1)
+		getUse, setUse = "get", "set <file>"
+	}
+
+	getCmd := &cobra.Command{
+		Use:   getUse,
+		Short: "Print the app's config as JSON",
+		Args:  getArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			appID, err := configTargetApp(useDefaultApp, args, false)
+			if err != nil {
+				return err
+			}
+			cv, err := newAppCloudService().GetConfig(appID)
+			if err != nil {
+				return err
+			}
+			out, err := json.MarshalIndent(cv.Config, "", "  ")
+			if err != nil {
+				return errors.Wrap(err, "render config")
+			}
+			fmt.Println(string(out))
+			return nil
+		},
+	}
+
+	var ifMatch string
+	setCmd := &cobra.Command{
+		Use:   setUse,
+		Short: "Replace the app's config from a JSON file (use - for stdin)",
+		Args:  setArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			printer := cprint.NewCPrinter(flags.VerboseFlag)
+			appID, err := configTargetApp(useDefaultApp, args, true)
+			if err != nil {
+				return err
+			}
+			file := args[len(args)-1]
+			raw, err := readFileOrStdin(file)
+			if err != nil {
+				return err
+			}
+			var cfg appcloud.AppConfig
+			if err := json.Unmarshal(raw, &cfg); err != nil {
+				return errors.Wrap(err, "parse config JSON")
+			}
+			if _, err := newAppCloudService().SetConfig(appID, cfg, ifMatch); err != nil {
+				return err
+			}
+			printer.Success("Updated config for app " + appID)
+			return nil
+		},
+	}
+	setCmd.Flags().StringVar(&ifMatch, "if-match", "", "Config etag for optimistic concurrency (rejects with 412 on mismatch)")
+
+	configCmd.AddCommand(getCmd, setCmd)
+	return configCmd
+}
+
+// configTargetApp resolves the app id for a config subcommand given whether it
+// uses the default app and whether the command also takes a trailing file arg.
+func configTargetApp(useDefaultApp bool, args []string, hasFileArg bool) (string, error) {
+	if useDefaultApp {
+		return resolveAppID("")
+	}
+	// Positional app id is the first argument in both get (<app-id>) and
+	// set (<app-id> <file>) forms.
+	_ = hasFileArg
+	return args[0], nil
+}
+
+func readFileOrStdin(path string) ([]byte, error) {
+	if path == "-" {
+		b, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, errors.Wrap(err, "read config from stdin")
+		}
+		return b, nil
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "read %s", path)
+	}
+	return b, nil
+}

--- a/cmd/appcloud/deploy.go
+++ b/cmd/appcloud/deploy.go
@@ -115,8 +115,12 @@ func resolveDeployApp(svc appcloud.AppCloudServicer, printer *cprint.CPrinter) (
 }
 
 func createDeployApp(svc appcloud.AppCloudServicer, printer *cprint.CPrinter) (appcloud.App, error) {
-	if deployName == "" || deployOwner == "" {
-		return appcloud.App{}, errors.New("creating a new app requires --name and --owner")
+	if deployName == "" {
+		return appcloud.App{}, errors.New("creating a new app requires --name")
+	}
+	owner, err := resolveOwner(deployOwner)
+	if err != nil {
+		return appcloud.App{}, err
 	}
 	orgID, err := flags.GetOrganizationID()
 	if err != nil {
@@ -126,7 +130,7 @@ func createDeployApp(svc appcloud.AppCloudServicer, printer *cprint.CPrinter) (a
 	if err != nil {
 		return appcloud.App{}, err
 	}
-	app, err := svc.CreateApp(deployOwner, deployName, orgID, projID, deployDomains)
+	app, err := svc.CreateApp(owner, deployName, orgID, projID, deployDomains)
 	if err != nil {
 		return appcloud.App{}, err
 	}
@@ -136,7 +140,7 @@ func createDeployApp(svc appcloud.AppCloudServicer, printer *cprint.CPrinter) (a
 
 func init() {
 	deployCmd.Flags().StringVar(&deployName, "name", "", "App name (URL-safe slug); required when creating")
-	deployCmd.Flags().StringVar(&deployOwner, "owner", "", "Owner label; required when creating")
+	deployCmd.Flags().StringVar(&deployOwner, "owner", "", "Owner label (default: your logged-in user)")
 	deployCmd.Flags().StringArrayVar(&deployDomains, "domain", nil, "Domain to attach (repeatable); the first is used to find an existing app")
 	deployCmd.Flags().StringVar(&deployKind, "kind", "static", "Revision kind")
 	deployCmd.Flags().StringVar(&deployArtifactRef, "artifact-ref", "", "Client artifact reference (default: {name}@{unix_ts})")

--- a/cmd/appcloud/deploy.go
+++ b/cmd/appcloud/deploy.go
@@ -2,12 +2,10 @@ package appcloud
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/Hyphen/cli/internal/appcloud"
 	"github.com/Hyphen/cli/pkg/cprint"
-	"github.com/Hyphen/cli/pkg/errors"
 	"github.com/Hyphen/cli/pkg/flags"
 	"github.com/spf13/cobra"
 )
@@ -36,9 +34,8 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		printer := cprint.NewCPrinter(flags.VerboseFlag)
 		name, dir := args[0], args[1]
-		info, err := os.Stat(dir)
-		if err != nil || !info.IsDir() {
-			return errors.Wrapf(errors.New("not a directory"), "%s", dir)
+		if err := requireDir(dir); err != nil {
+			return err
 		}
 		svc := newAppCloudService()
 

--- a/cmd/appcloud/deploy.go
+++ b/cmd/appcloud/deploy.go
@@ -1,0 +1,145 @@
+package appcloud
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Hyphen/cli/internal/appcloud"
+	"github.com/Hyphen/cli/pkg/cprint"
+	"github.com/Hyphen/cli/pkg/errors"
+	"github.com/Hyphen/cli/pkg/flags"
+	"github.com/spf13/cobra"
+)
+
+var (
+	deployName        string
+	deployOwner       string
+	deployDomains     []string
+	deployKind        string
+	deployArtifactRef string
+	deployBatchSize   int
+	deployNoActivate  bool
+)
+
+var deployCmd = &cobra.Command{
+	Use:   "deploy <dir>",
+	Short: "Deploy a directory to AppCloud (create-or-find app, upload, activate)",
+	Long: `
+End-to-end deploy: find the app by its first --domain (or create one), register
+a new revision, upload the directory's contents, and pin it active.
+
+Examples:
+  hx appcloud deploy ./dist --name my-site --owner me --domain my-site.app.hyphen.cloud
+  hx appcloud deploy ./public --name docs --owner me --domain docs.acme.com --no-activate`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		printer := cprint.NewCPrinter(flags.VerboseFlag)
+		dir := args[0]
+		info, err := os.Stat(dir)
+		if err != nil || !info.IsDir() {
+			return errors.Wrapf(errors.New("not a directory"), "%s", dir)
+		}
+		svc := newAppCloudService()
+
+		app, err := resolveDeployApp(svc, printer)
+		if err != nil {
+			return err
+		}
+		return shipRevision(svc, printer, app, dir, deployKind, deployArtifactRef, deployBatchSize, deployNoActivate)
+	},
+}
+
+// shipRevision registers a revision, uploads `dir`, and (unless noActivate)
+// pins it active — the shared tail of `deploy` and `apps deploy`.
+func shipRevision(svc appcloud.AppCloudServicer, printer *cprint.CPrinter, app appcloud.App, dir, kind, artifactRef string, batchSize int, noActivate bool) error {
+	if artifactRef == "" {
+		artifactRef = fmt.Sprintf("%s@%d", app.Name, time.Now().Unix())
+	}
+	rev, err := svc.CreateRevision(app.ID, kind, artifactRef)
+	if err != nil {
+		return err
+	}
+	printer.Info(fmt.Sprintf("registered revision %s (%s)", rev.Hex, rev.ArtifactRef))
+
+	n, err := appcloud.UploadDirectory(svc, app.ID, rev.Hex, dir, batchSize, func(msg string) { printer.Print(msg) })
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		printer.Warning(fmt.Sprintf("nothing to upload (no files under %s)", dir))
+	}
+
+	if noActivate {
+		printer.Info("revision uploaded but NOT activated (--no-activate)")
+		if rev.PreviewURL != "" {
+			printer.Print("preview: " + rev.PreviewURL)
+		}
+		return nil
+	}
+	updated, err := svc.SetActiveRevision(app.ID, rev.Hex)
+	if err != nil {
+		return err
+	}
+	printer.Success("pinned active revision: " + rev.Hex)
+	if rev.PreviewURL != "" {
+		printer.Print("preview: " + rev.PreviewURL)
+	}
+	for _, d := range updated.Domains {
+		printer.Print("live at: https://" + d + "/")
+	}
+	return nil
+}
+
+// resolveDeployApp finds the target app by its first domain, or creates one.
+// When an existing app matches the domain, its owner/name must match the flags
+// so a deploy can't silently ship into a foreign app that shares a domain.
+func resolveDeployApp(svc appcloud.AppCloudServicer, printer *cprint.CPrinter) (appcloud.App, error) {
+	if len(deployDomains) > 0 {
+		existing, err := svc.FindAppByDomain(deployDomains[0])
+		if err != nil {
+			return appcloud.App{}, err
+		}
+		if existing != nil {
+			if deployOwner != "" && existing.Owner != deployOwner ||
+				deployName != "" && existing.Name != deployName {
+				return appcloud.App{}, fmt.Errorf(
+					"domain %s is already attached to app %s (owner=%s, name=%s); refusing to deploy with mismatched --owner/--name",
+					deployDomains[0], existing.ID, existing.Owner, existing.Name)
+			}
+			printer.Info(fmt.Sprintf("found existing app %s for %s", existing.ID, deployDomains[0]))
+			return *existing, nil
+		}
+	}
+	return createDeployApp(svc, printer)
+}
+
+func createDeployApp(svc appcloud.AppCloudServicer, printer *cprint.CPrinter) (appcloud.App, error) {
+	if deployName == "" || deployOwner == "" {
+		return appcloud.App{}, errors.New("creating a new app requires --name and --owner")
+	}
+	orgID, err := flags.GetOrganizationID()
+	if err != nil {
+		return appcloud.App{}, err
+	}
+	projID, err := flags.GetProjectID()
+	if err != nil {
+		return appcloud.App{}, err
+	}
+	app, err := svc.CreateApp(deployOwner, deployName, orgID, projID, deployDomains)
+	if err != nil {
+		return appcloud.App{}, err
+	}
+	printer.Success(fmt.Sprintf("created app %s (%s)", app.ID, app.Name))
+	return app, nil
+}
+
+func init() {
+	deployCmd.Flags().StringVar(&deployName, "name", "", "App name (URL-safe slug); required when creating")
+	deployCmd.Flags().StringVar(&deployOwner, "owner", "", "Owner label; required when creating")
+	deployCmd.Flags().StringArrayVar(&deployDomains, "domain", nil, "Domain to attach (repeatable); the first is used to find an existing app")
+	deployCmd.Flags().StringVar(&deployKind, "kind", "static", "Revision kind")
+	deployCmd.Flags().StringVar(&deployArtifactRef, "artifact-ref", "", "Client artifact reference (default: {name}@{unix_ts})")
+	deployCmd.Flags().IntVar(&deployBatchSize, "batch-size", 100, "Max files per upload request")
+	deployCmd.Flags().BoolVar(&deployNoActivate, "no-activate", false, "Upload the revision without pinning it active")
+}

--- a/cmd/appcloud/deploy.go
+++ b/cmd/appcloud/deploy.go
@@ -13,7 +13,6 @@ import (
 )
 
 var (
-	deployName        string
 	deployOwner       string
 	deployDomains     []string
 	deployKind        string
@@ -23,26 +22,27 @@ var (
 )
 
 var deployCmd = &cobra.Command{
-	Use:   "deploy <dir>",
-	Short: "Deploy a directory to AppCloud (create-or-find app, upload, activate)",
+	Use:   "deploy <name> <dir>",
+	Short: "Deploy a directory to an AppCloud app (create-or-find, upload, activate)",
 	Long: `
-End-to-end deploy: find the app by its first --domain (or create one), register
-a new revision, upload the directory's contents, and pin it active.
+End-to-end deploy of <dir> to the app named <name>: find the app (by its first
+--domain, else by name), or create it, then register a revision, upload the
+directory's contents, and pin it active.
 
 Examples:
-  hx appcloud deploy ./dist --name my-site --owner me --domain my-site.app.hyphen.cloud
-  hx appcloud deploy ./public --name docs --owner me --domain docs.acme.com --no-activate`,
-	Args: cobra.ExactArgs(1),
+  hx appcloud deploy my-site ./dist --domain my-site.app.hyphen.cloud
+  hx appcloud deploy docs ./public --domain docs.acme.com --no-activate`,
+	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		printer := cprint.NewCPrinter(flags.VerboseFlag)
-		dir := args[0]
+		name, dir := args[0], args[1]
 		info, err := os.Stat(dir)
 		if err != nil || !info.IsDir() {
 			return errors.Wrapf(errors.New("not a directory"), "%s", dir)
 		}
 		svc := newAppCloudService()
 
-		app, err := resolveDeployApp(svc, printer)
+		app, err := resolveDeployApp(svc, printer, name)
 		if err != nil {
 			return err
 		}
@@ -91,33 +91,30 @@ func shipRevision(svc appcloud.AppCloudServicer, printer *cprint.CPrinter, app a
 	return nil
 }
 
-// resolveDeployApp finds the target app by its first domain, or creates one.
-// When an existing app matches the domain, its owner/name must match the flags
-// so a deploy can't silently ship into a foreign app that shares a domain.
-func resolveDeployApp(svc appcloud.AppCloudServicer, printer *cprint.CPrinter) (appcloud.App, error) {
+// resolveDeployApp finds the target app for `name` — by its first domain if
+// one is given, else by name — or creates it. When an existing app is found
+// by domain, its name must match so a deploy can't silently ship into a
+// foreign app that happens to share a domain.
+func resolveDeployApp(svc appcloud.AppCloudServicer, printer *cprint.CPrinter, name string) (appcloud.App, error) {
 	if len(deployDomains) > 0 {
 		existing, err := svc.FindAppByDomain(deployDomains[0])
 		if err != nil {
 			return appcloud.App{}, err
 		}
 		if existing != nil {
-			if deployOwner != "" && existing.Owner != deployOwner ||
-				deployName != "" && existing.Name != deployName {
+			if existing.Name != name {
 				return appcloud.App{}, fmt.Errorf(
-					"domain %s is already attached to app %s (owner=%s, name=%s); refusing to deploy with mismatched --owner/--name",
-					deployDomains[0], existing.ID, existing.Owner, existing.Name)
+					"domain %s is already attached to app %s (name=%s); refusing to deploy as %q",
+					deployDomains[0], existing.ID, existing.Name, name)
 			}
 			printer.Info(fmt.Sprintf("found existing app %s for %s", existing.ID, deployDomains[0]))
 			return *existing, nil
 		}
 	}
-	return createDeployApp(svc, printer)
+	return createDeployApp(svc, printer, name)
 }
 
-func createDeployApp(svc appcloud.AppCloudServicer, printer *cprint.CPrinter) (appcloud.App, error) {
-	if deployName == "" {
-		return appcloud.App{}, errors.New("creating a new app requires --name")
-	}
+func createDeployApp(svc appcloud.AppCloudServicer, printer *cprint.CPrinter, name string) (appcloud.App, error) {
 	owner, err := resolveOwner(deployOwner)
 	if err != nil {
 		return appcloud.App{}, err
@@ -130,7 +127,7 @@ func createDeployApp(svc appcloud.AppCloudServicer, printer *cprint.CPrinter) (a
 	if err != nil {
 		return appcloud.App{}, err
 	}
-	app, err := svc.CreateApp(owner, deployName, orgID, projID, deployDomains)
+	app, err := svc.CreateApp(owner, name, orgID, projID, deployDomains)
 	if err != nil {
 		return appcloud.App{}, err
 	}
@@ -139,7 +136,6 @@ func createDeployApp(svc appcloud.AppCloudServicer, printer *cprint.CPrinter) (a
 }
 
 func init() {
-	deployCmd.Flags().StringVar(&deployName, "name", "", "App name (URL-safe slug); required when creating")
 	deployCmd.Flags().StringVar(&deployOwner, "owner", "", "Owner label (default: your logged-in user)")
 	deployCmd.Flags().StringArrayVar(&deployDomains, "domain", nil, "Domain to attach (repeatable); the first is used to find an existing app")
 	deployCmd.Flags().StringVar(&deployKind, "kind", "static", "Revision kind")

--- a/cmd/appcloud/metrics.go
+++ b/cmd/appcloud/metrics.go
@@ -1,0 +1,104 @@
+package appcloud
+
+import (
+	"fmt"
+
+	"github.com/Hyphen/cli/internal/appcloud"
+	"github.com/Hyphen/cli/pkg/cprint"
+	"github.com/Hyphen/cli/pkg/flags"
+	"github.com/spf13/cobra"
+)
+
+var metricsCmd = &cobra.Command{
+	Use:   "metrics",
+	Short: "Query gateway telemetry (HTTP traffic and error logs)",
+}
+
+var (
+	metricsApp    string
+	metricsDomain string
+	metricsMethod string
+	metricsKind   string
+	metricsStatus int
+	metricsFrom   string
+	metricsTo     string
+	metricsLimit  int
+)
+
+var metricsHTTPCmd = &cobra.Command{
+	Use:   "http",
+	Short: "Gateway HTTP traffic logs (one row per served request)",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		printer := cprint.NewCPrinter(flags.VerboseFlag)
+		rows, err := newAppCloudService().QueryHTTPMetrics(appcloud.HTTPMetricsParams{
+			AppID:  metricsApp,
+			Domain: metricsDomain,
+			Method: metricsMethod,
+			Status: metricsStatus,
+			From:   metricsFrom,
+			To:     metricsTo,
+			Limit:  metricsLimit,
+		})
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			printer.Info("No HTTP logs found.")
+			return nil
+		}
+		for _, r := range rows {
+			cache := "miss"
+			if r.CacheHit {
+				cache = "hit"
+			}
+			printer.Print(fmt.Sprintf("%s  %3d  %-6s %s%s  %dms  %dB  [%s]",
+				r.TS, r.Status, r.Method, r.Domain, r.Path, r.DurationMS, r.Bytes, cache))
+		}
+		return nil
+	},
+}
+
+var metricsErrorsCmd = &cobra.Command{
+	Use:   "errors",
+	Short: "Gateway error logs (failures attributable to a domain)",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		printer := cprint.NewCPrinter(flags.VerboseFlag)
+		rows, err := newAppCloudService().QueryErrorMetrics(appcloud.ErrorMetricsParams{
+			AppID:  metricsApp,
+			Domain: metricsDomain,
+			Kind:   metricsKind,
+			From:   metricsFrom,
+			To:     metricsTo,
+			Limit:  metricsLimit,
+		})
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			printer.Info("No error logs found.")
+			return nil
+		}
+		for _, r := range rows {
+			printer.Print(fmt.Sprintf("%s  %-16s %s  %s", r.TS, r.Kind, r.Domain, r.Message))
+		}
+		return nil
+	},
+}
+
+func init() {
+	for _, c := range []*cobra.Command{metricsHTTPCmd, metricsErrorsCmd} {
+		c.Flags().StringVar(&metricsApp, "app", "", "Filter by app id")
+		c.Flags().StringVar(&metricsDomain, "domain", "", "Filter by domain")
+		c.Flags().StringVar(&metricsFrom, "from", "", "Start of the time window (RFC3339)")
+		c.Flags().StringVar(&metricsTo, "to", "", "End of the time window (RFC3339)")
+		c.Flags().IntVar(&metricsLimit, "limit", 0, "Max rows to return")
+	}
+	metricsHTTPCmd.Flags().StringVar(&metricsMethod, "method", "", "Filter by HTTP method")
+	metricsHTTPCmd.Flags().IntVar(&metricsStatus, "status", 0, "Filter by exact status code")
+	metricsErrorsCmd.Flags().StringVar(&metricsKind, "kind", "", "Filter by error kind")
+
+	metricsCmd.AddCommand(metricsHTTPCmd)
+	metricsCmd.AddCommand(metricsErrorsCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/Hyphen/cli/cmd/app"
+	"github.com/Hyphen/cli/cmd/appcloud"
 	"github.com/Hyphen/cli/cmd/auth"
 	"github.com/Hyphen/cli/cmd/autoinit"
 	"github.com/Hyphen/cli/cmd/build"
@@ -93,6 +94,10 @@ func Execute() {
 	if canUseDeployments {
 		rootCmd.AddCommand(deploy.DeployCmd)
 		rootCmd.AddCommand(build.BuildCmd)
+	}
+	canUseAppcloud := toggle.GetBooleanValue("canUseAppcloud", false)
+	if canUseAppcloud {
+		rootCmd.AddCommand(appcloud.AppCloudCmd)
 	}
 	if err := rootCmd.Execute(); err != nil {
 		cprint.Error(rootCmd, err, flags.VerboseFlag)

--- a/internal/appcloud/models.go
+++ b/internal/appcloud/models.go
@@ -16,13 +16,64 @@ type App struct {
 	UpdatedAt      string    `json:"updatedAt"`
 }
 
-// AppConfig is the app's routing/serving config as returned by the API. It is
-// intentionally permissive: the management API owns the schema, so we keep the
-// raw representation and only pull out what the CLI needs.
+// AppConfig is the app's routing/serving config. The management API owns the
+// schema; the CLI keeps the raw representation and round-trips it verbatim.
 type AppConfig map[string]any
 
-// listResponse is the shape of `GET /v1/apps` (items + optional cursor).
-type listResponse struct {
-	Items      []App  `json:"items"`
+// Revision mirrors the management `RevisionView`.
+type Revision struct {
+	ID          string `json:"id"`
+	AppID       string `json:"appId"`
+	Hex         string `json:"hex"`
+	Kind        string `json:"kind"`
+	ArtifactRef string `json:"artifactRef"`
+	PreviewURL  string `json:"previewUrl"`
+	CreatedAt   string `json:"createdAt"`
+}
+
+// ConfigView is the body of `GET`/`PUT /v1/apps/{id}/config`.
+type ConfigView struct {
+	Config     AppConfig `json:"config"`
+	ConfigETag string    `json:"configEtag"`
+}
+
+// UploadResponse is the body of a revision file-upload batch.
+type UploadResponse struct {
+	Files []UploadedFile `json:"files"`
+}
+
+type UploadedFile struct {
+	Path string `json:"path"`
+	Key  string `json:"key"`
+	Size uint64 `json:"size"`
+}
+
+// HTTPLog mirrors management's `HttpLogView` (one served request).
+type HTTPLog struct {
+	ID         string `json:"id"`
+	TS         string `json:"ts"`
+	Domain     string `json:"domain"`
+	Method     string `json:"method"`
+	Path       string `json:"path"`
+	Status     int    `json:"status"`
+	Bytes      uint64 `json:"bytes"`
+	DurationMS uint64 `json:"durationMs"`
+	Revision   string `json:"revision"`
+	CacheHit   bool   `json:"cacheHit"`
+}
+
+// ErrorLog mirrors management's `ErrorLogView`.
+type ErrorLog struct {
+	ID       string `json:"id"`
+	TS       string `json:"ts"`
+	Domain   string `json:"domain"`
+	Kind     string `json:"kind"`
+	Message  string `json:"message"`
+	Revision string `json:"revision"`
+}
+
+// listResponse is the generic `{items, nextCursor}` envelope.
+type listResponse[T any] struct {
+	Items      []T    `json:"items"`
 	NextCursor string `json:"nextCursor"`
 }

--- a/internal/appcloud/models.go
+++ b/internal/appcloud/models.go
@@ -1,0 +1,28 @@
+package appcloud
+
+// App mirrors the AppCloud management API `AppView` (camelCase JSON). Only the
+// fields the CLI surfaces are modelled; unknown fields are ignored.
+type App struct {
+	ID             string    `json:"id"`
+	Owner          string    `json:"owner"`
+	Name           string    `json:"name"`
+	OrganizationID string    `json:"organizationId"`
+	ProjectID      string    `json:"projectId"`
+	Domains        []string  `json:"domains"`
+	ActiveRevision string    `json:"activeRevision"`
+	Config         AppConfig `json:"config"`
+	ConfigETag     string    `json:"configEtag"`
+	CreatedAt      string    `json:"createdAt"`
+	UpdatedAt      string    `json:"updatedAt"`
+}
+
+// AppConfig is the app's routing/serving config as returned by the API. It is
+// intentionally permissive: the management API owns the schema, so we keep the
+// raw representation and only pull out what the CLI needs.
+type AppConfig map[string]any
+
+// listResponse is the shape of `GET /v1/apps` (items + optional cursor).
+type listResponse struct {
+	Items      []App  `json:"items"`
+	NextCursor string `json:"nextCursor"`
+}

--- a/internal/appcloud/service.go
+++ b/internal/appcloud/service.go
@@ -1,6 +1,7 @@
 package appcloud
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,15 +14,24 @@ import (
 )
 
 // AppCloudServicer is the AppCloud management API surface the CLI depends on.
-// Kept small and interface-first so commands can be tested against a mock.
 type AppCloudServicer interface {
 	ListApps(organizationID, projectID string) ([]App, error)
-	GetApp(organizationID, appID string) (App, error)
+	GetApp(appID string) (App, error)
+	FindAppByDomain(domain string) (*App, error)
+	CreateApp(owner, name, organizationID, projectID string, domains []string) (App, error)
+	DeleteApp(appID string) error
+	CreateRevision(appID, kind, artifactRef string) (Revision, error)
+	UploadBatch(appID, hex string, body io.Reader, contentType string) (UploadResponse, error)
+	SetActiveRevision(appID, hex string) (App, error)
+	GetConfig(appID string) (ConfigView, error)
+	SetConfig(appID string, config AppConfig, ifMatch string) (ConfigView, error)
+	QueryHTTPMetrics(params HTTPMetricsParams) ([]HTTPLog, error)
+	QueryErrorMetrics(params ErrorMetricsParams) ([]ErrorLog, error)
 }
 
 // AppCloudService talks to the AppCloud management control plane. Auth is
-// handled by the shared Hyphen HTTP client, which attaches the caller's OAuth
-// bearer token; the base URL follows the standard dev/local/prod switch.
+// handled by the shared Hyphen HTTP client (OAuth bearer / x-api-key); the
+// base URL follows the standard dev/local/prod switch.
 type AppCloudService struct {
 	baseUrl    string
 	httpClient httputil.Client
@@ -36,8 +46,43 @@ func NewService() *AppCloudService {
 	}
 }
 
-// ListApps returns the apps visible to the caller in an organization,
-// optionally narrowed to a project. Follows the cursor to return all pages.
+// do issues a JSON request. `payload` (if non-nil) is marshalled as the body;
+// `out` (if non-nil) is unmarshalled from a successful response. `okStatus` is
+// the expected success code.
+func (s *AppCloudService) do(method, path string, payload, out any, okStatus int) error {
+	var body io.Reader
+	if payload != nil {
+		b, err := json.Marshal(payload)
+		if err != nil {
+			return errors.Wrap(err, "Failed to marshal request payload")
+		}
+		body = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, s.baseUrl+path, body)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create request")
+	}
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != okStatus {
+		return errors.HandleHTTPError(resp)
+	}
+	if out == nil {
+		return nil
+	}
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "Failed to read response body")
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return errors.Wrap(err, "Failed to parse JSON response")
+	}
+	return nil
+}
+
 func (s *AppCloudService) ListApps(organizationID, projectID string) ([]App, error) {
 	var apps []App
 	cursor := ""
@@ -50,23 +95,10 @@ func (s *AppCloudService) ListApps(organizationID, projectID string) ([]App, err
 		if cursor != "" {
 			q.Set("cursor", cursor)
 		}
-		endpoint := fmt.Sprintf("%s/v1/apps?%s", s.baseUrl, q.Encode())
-
-		req, err := http.NewRequest(http.MethodGet, endpoint, nil)
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to create request")
-		}
-
-		resp, err := s.httpClient.Do(req)
-		if err != nil {
+		var page listResponse[App]
+		if err := s.do(http.MethodGet, "/v1/apps?"+q.Encode(), nil, &page, http.StatusOK); err != nil {
 			return nil, err
 		}
-
-		page, err := decodeListResponse(resp)
-		if err != nil {
-			return nil, err
-		}
-
 		apps = append(apps, page.Items...)
 		if page.NextCursor == "" {
 			break
@@ -76,53 +108,192 @@ func (s *AppCloudService) ListApps(organizationID, projectID string) ([]App, err
 	return apps, nil
 }
 
-// GetApp fetches a single app by id (the management API scopes it to the
-// caller's org membership; a hidden app surfaces as not found).
-func (s *AppCloudService) GetApp(organizationID, appID string) (App, error) {
-	endpoint := fmt.Sprintf("%s/v1/apps/%s", s.baseUrl, url.PathEscape(appID))
-
-	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
-	if err != nil {
-		return App{}, errors.Wrap(err, "Failed to create request")
-	}
-
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		return App{}, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return App{}, errors.HandleHTTPError(resp)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return App{}, errors.Wrap(err, "Failed to read response body")
-	}
-
+func (s *AppCloudService) GetApp(appID string) (App, error) {
 	var app App
-	if err := json.Unmarshal(body, &app); err != nil {
-		return App{}, errors.Wrap(err, "Failed to parse JSON response")
-	}
-	return app, nil
+	err := s.do(http.MethodGet, "/v1/apps/"+url.PathEscape(appID), nil, &app, http.StatusOK)
+	return app, err
 }
 
-func decodeListResponse(resp *http.Response) (listResponse, error) {
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return listResponse{}, errors.HandleHTTPError(resp)
+// FindAppByDomain returns the app that owns `domain`, or nil if none. Domain
+// uniqueness is a server invariant, so >1 match is a hard error.
+func (s *AppCloudService) FindAppByDomain(domain string) (*App, error) {
+	q := url.Values{}
+	q.Set("domain", domain)
+	var page listResponse[App]
+	if err := s.do(http.MethodGet, "/v1/apps?"+q.Encode(), nil, &page, http.StatusOK); err != nil {
+		return nil, err
 	}
+	switch len(page.Items) {
+	case 0:
+		return nil, nil
+	case 1:
+		return &page.Items[0], nil
+	default:
+		return nil, fmt.Errorf("management returned %d apps for domain %s; expected 0 or 1", len(page.Items), domain)
+	}
+}
 
-	body, err := io.ReadAll(resp.Body)
+func (s *AppCloudService) CreateApp(owner, name, organizationID, projectID string, domains []string) (App, error) {
+	if domains == nil {
+		domains = []string{}
+	}
+	payload := map[string]any{
+		"owner":          owner,
+		"name":           name,
+		"organizationId": organizationID,
+		"projectId":      projectID,
+		"domains":        domains,
+		"config":         map[string]any{},
+	}
+	var app App
+	err := s.do(http.MethodPost, "/v1/apps", payload, &app, http.StatusCreated)
+	return app, err
+}
+
+func (s *AppCloudService) DeleteApp(appID string) error {
+	return s.do(http.MethodDelete, "/v1/apps/"+url.PathEscape(appID), nil, nil, http.StatusNoContent)
+}
+
+func (s *AppCloudService) CreateRevision(appID, kind, artifactRef string) (Revision, error) {
+	payload := map[string]any{"kind": kind, "artifactRef": artifactRef}
+	var rev Revision
+	err := s.do(http.MethodPost, "/v1/apps/"+url.PathEscape(appID)+"/revisions", payload, &rev, http.StatusCreated)
+	return rev, err
+}
+
+// UploadBatch POSTs a pre-built multipart body (see upload.go) of gzipped
+// files for a revision.
+func (s *AppCloudService) UploadBatch(appID, hex string, body io.Reader, contentType string) (UploadResponse, error) {
+	var out UploadResponse
+	path := fmt.Sprintf("/v1/apps/%s/revisions/%s/files", url.PathEscape(appID), url.PathEscape(hex))
+	req, err := http.NewRequest(http.MethodPost, s.baseUrl+path, body)
 	if err != nil {
-		return listResponse{}, errors.Wrap(err, "Failed to read response body")
+		return out, errors.Wrap(err, "Failed to create request")
 	}
+	req.Header.Set("Content-Type", contentType)
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return out, err
+	}
+	defer resp.Body.Close()
+	// The upload endpoint returns 201 Created; accept any 2xx.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return out, errors.HandleHTTPError(resp)
+	}
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return out, errors.Wrap(err, "Failed to read response body")
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return out, errors.Wrap(err, "Failed to parse JSON response")
+	}
+	return out, nil
+}
 
-	var page listResponse
-	if err := json.Unmarshal(body, &page); err != nil {
-		return listResponse{}, errors.Wrap(err, "Failed to parse JSON response")
+func (s *AppCloudService) SetActiveRevision(appID, hex string) (App, error) {
+	payload := map[string]any{"activeRevision": hex}
+	var app App
+	err := s.do(http.MethodPatch, "/v1/apps/"+url.PathEscape(appID), payload, &app, http.StatusOK)
+	return app, err
+}
+
+func (s *AppCloudService) GetConfig(appID string) (ConfigView, error) {
+	var cv ConfigView
+	err := s.do(http.MethodGet, "/v1/apps/"+url.PathEscape(appID)+"/config", nil, &cv, http.StatusOK)
+	return cv, err
+}
+
+// SetConfig replaces the app's config. `ifMatch` (if non-empty) sends an
+// If-Match header for optimistic concurrency (412 on mismatch).
+func (s *AppCloudService) SetConfig(appID string, config AppConfig, ifMatch string) (ConfigView, error) {
+	var cv ConfigView
+	b, err := json.Marshal(config)
+	if err != nil {
+		return cv, errors.Wrap(err, "Failed to marshal config")
 	}
-	return page, nil
+	req, err := http.NewRequest(http.MethodPut, s.baseUrl+"/v1/apps/"+url.PathEscape(appID)+"/config", bytes.NewReader(b))
+	if err != nil {
+		return cv, errors.Wrap(err, "Failed to create request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if ifMatch != "" {
+		req.Header.Set("If-Match", ifMatch)
+	}
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return cv, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return cv, errors.HandleHTTPError(resp)
+	}
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return cv, errors.Wrap(err, "Failed to read response body")
+	}
+	if err := json.Unmarshal(raw, &cv); err != nil {
+		return cv, errors.Wrap(err, "Failed to parse JSON response")
+	}
+	return cv, nil
+}
+
+// HTTPMetricsParams are the filters for `GET /v1/metrics/http`. Empty fields
+// are omitted so the server defaults apply.
+type HTTPMetricsParams struct {
+	AppID  string
+	Domain string
+	Method string
+	Status int
+	From   string
+	To     string
+	Limit  int
+}
+
+// ErrorMetricsParams are the filters for `GET /v1/metrics/errors`.
+type ErrorMetricsParams struct {
+	AppID  string
+	Domain string
+	Kind   string
+	From   string
+	To     string
+	Limit  int
+}
+
+func (s *AppCloudService) QueryHTTPMetrics(params HTTPMetricsParams) ([]HTTPLog, error) {
+	q := url.Values{}
+	setStr(q, "appId", params.AppID)
+	setStr(q, "domain", params.Domain)
+	setStr(q, "method", params.Method)
+	setInt(q, "status", params.Status)
+	setStr(q, "from", params.From)
+	setStr(q, "to", params.To)
+	setInt(q, "limit", params.Limit)
+	var page listResponse[HTTPLog]
+	err := s.do(http.MethodGet, "/v1/metrics/http?"+q.Encode(), nil, &page, http.StatusOK)
+	return page.Items, err
+}
+
+func (s *AppCloudService) QueryErrorMetrics(params ErrorMetricsParams) ([]ErrorLog, error) {
+	q := url.Values{}
+	setStr(q, "appId", params.AppID)
+	setStr(q, "domain", params.Domain)
+	setStr(q, "kind", params.Kind)
+	setStr(q, "from", params.From)
+	setStr(q, "to", params.To)
+	setInt(q, "limit", params.Limit)
+	var page listResponse[ErrorLog]
+	err := s.do(http.MethodGet, "/v1/metrics/errors?"+q.Encode(), nil, &page, http.StatusOK)
+	return page.Items, err
+}
+
+func setStr(q url.Values, key, val string) {
+	if val != "" {
+		q.Set(key, val)
+	}
+}
+
+func setInt(q url.Values, key string, val int) {
+	if val != 0 {
+		q.Set(key, fmt.Sprintf("%d", val))
+	}
 }

--- a/internal/appcloud/service.go
+++ b/internal/appcloud/service.go
@@ -1,0 +1,128 @@
+package appcloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/Hyphen/cli/pkg/apiconf"
+	"github.com/Hyphen/cli/pkg/errors"
+	"github.com/Hyphen/cli/pkg/httputil"
+)
+
+// AppCloudServicer is the AppCloud management API surface the CLI depends on.
+// Kept small and interface-first so commands can be tested against a mock.
+type AppCloudServicer interface {
+	ListApps(organizationID, projectID string) ([]App, error)
+	GetApp(organizationID, appID string) (App, error)
+}
+
+// AppCloudService talks to the AppCloud management control plane. Auth is
+// handled by the shared Hyphen HTTP client, which attaches the caller's OAuth
+// bearer token; the base URL follows the standard dev/local/prod switch.
+type AppCloudService struct {
+	baseUrl    string
+	httpClient httputil.Client
+}
+
+var _ AppCloudServicer = (*AppCloudService)(nil)
+
+func NewService() *AppCloudService {
+	return &AppCloudService{
+		baseUrl:    apiconf.GetBaseAppCloudUrl(),
+		httpClient: httputil.NewHyphenHTTPClient(),
+	}
+}
+
+// ListApps returns the apps visible to the caller in an organization,
+// optionally narrowed to a project. Follows the cursor to return all pages.
+func (s *AppCloudService) ListApps(organizationID, projectID string) ([]App, error) {
+	var apps []App
+	cursor := ""
+	for {
+		q := url.Values{}
+		q.Set("organizationId", organizationID)
+		if projectID != "" {
+			q.Set("projectId", projectID)
+		}
+		if cursor != "" {
+			q.Set("cursor", cursor)
+		}
+		endpoint := fmt.Sprintf("%s/v1/apps?%s", s.baseUrl, q.Encode())
+
+		req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to create request")
+		}
+
+		resp, err := s.httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		page, err := decodeListResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		apps = append(apps, page.Items...)
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	return apps, nil
+}
+
+// GetApp fetches a single app by id (the management API scopes it to the
+// caller's org membership; a hidden app surfaces as not found).
+func (s *AppCloudService) GetApp(organizationID, appID string) (App, error) {
+	endpoint := fmt.Sprintf("%s/v1/apps/%s", s.baseUrl, url.PathEscape(appID))
+
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return App{}, errors.Wrap(err, "Failed to create request")
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return App{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return App{}, errors.HandleHTTPError(resp)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return App{}, errors.Wrap(err, "Failed to read response body")
+	}
+
+	var app App
+	if err := json.Unmarshal(body, &app); err != nil {
+		return App{}, errors.Wrap(err, "Failed to parse JSON response")
+	}
+	return app, nil
+}
+
+func decodeListResponse(resp *http.Response) (listResponse, error) {
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return listResponse{}, errors.HandleHTTPError(resp)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return listResponse{}, errors.Wrap(err, "Failed to read response body")
+	}
+
+	var page listResponse
+	if err := json.Unmarshal(body, &page); err != nil {
+		return listResponse{}, errors.Wrap(err, "Failed to parse JSON response")
+	}
+	return page, nil
+}

--- a/internal/appcloud/service_mock.go
+++ b/internal/appcloud/service_mock.go
@@ -1,0 +1,20 @@
+package appcloud
+
+import "github.com/stretchr/testify/mock"
+
+// MockAppCloudService is a testify mock of AppCloudServicer.
+type MockAppCloudService struct {
+	mock.Mock
+}
+
+var _ AppCloudServicer = (*MockAppCloudService)(nil)
+
+func (m *MockAppCloudService) ListApps(organizationID, projectID string) ([]App, error) {
+	args := m.Called(organizationID, projectID)
+	return args.Get(0).([]App), args.Error(1)
+}
+
+func (m *MockAppCloudService) GetApp(organizationID, appID string) (App, error) {
+	args := m.Called(organizationID, appID)
+	return args.Get(0).(App), args.Error(1)
+}

--- a/internal/appcloud/service_mock.go
+++ b/internal/appcloud/service_mock.go
@@ -1,6 +1,10 @@
 package appcloud
 
-import "github.com/stretchr/testify/mock"
+import (
+	"io"
+
+	"github.com/stretchr/testify/mock"
+)
 
 // MockAppCloudService is a testify mock of AppCloudServicer.
 type MockAppCloudService struct {
@@ -14,7 +18,58 @@ func (m *MockAppCloudService) ListApps(organizationID, projectID string) ([]App,
 	return args.Get(0).([]App), args.Error(1)
 }
 
-func (m *MockAppCloudService) GetApp(organizationID, appID string) (App, error) {
-	args := m.Called(organizationID, appID)
+func (m *MockAppCloudService) GetApp(appID string) (App, error) {
+	args := m.Called(appID)
 	return args.Get(0).(App), args.Error(1)
+}
+
+func (m *MockAppCloudService) FindAppByDomain(domain string) (*App, error) {
+	args := m.Called(domain)
+	app, _ := args.Get(0).(*App)
+	return app, args.Error(1)
+}
+
+func (m *MockAppCloudService) CreateApp(owner, name, organizationID, projectID string, domains []string) (App, error) {
+	args := m.Called(owner, name, organizationID, projectID, domains)
+	return args.Get(0).(App), args.Error(1)
+}
+
+func (m *MockAppCloudService) DeleteApp(appID string) error {
+	args := m.Called(appID)
+	return args.Error(0)
+}
+
+func (m *MockAppCloudService) CreateRevision(appID, kind, artifactRef string) (Revision, error) {
+	args := m.Called(appID, kind, artifactRef)
+	return args.Get(0).(Revision), args.Error(1)
+}
+
+func (m *MockAppCloudService) UploadBatch(appID, hex string, body io.Reader, contentType string) (UploadResponse, error) {
+	args := m.Called(appID, hex, body, contentType)
+	return args.Get(0).(UploadResponse), args.Error(1)
+}
+
+func (m *MockAppCloudService) SetActiveRevision(appID, hex string) (App, error) {
+	args := m.Called(appID, hex)
+	return args.Get(0).(App), args.Error(1)
+}
+
+func (m *MockAppCloudService) GetConfig(appID string) (ConfigView, error) {
+	args := m.Called(appID)
+	return args.Get(0).(ConfigView), args.Error(1)
+}
+
+func (m *MockAppCloudService) SetConfig(appID string, config AppConfig, ifMatch string) (ConfigView, error) {
+	args := m.Called(appID, config, ifMatch)
+	return args.Get(0).(ConfigView), args.Error(1)
+}
+
+func (m *MockAppCloudService) QueryHTTPMetrics(params HTTPMetricsParams) ([]HTTPLog, error) {
+	args := m.Called(params)
+	return args.Get(0).([]HTTPLog), args.Error(1)
+}
+
+func (m *MockAppCloudService) QueryErrorMetrics(params ErrorMetricsParams) ([]ErrorLog, error) {
+	args := m.Called(params)
+	return args.Get(0).([]ErrorLog), args.Error(1)
 }

--- a/internal/appcloud/service_test.go
+++ b/internal/appcloud/service_test.go
@@ -106,7 +106,7 @@ func TestGetApp(t *testing.T) {
 			Body:       io.NopCloser(strings.NewReader(responseBody)),
 		}, nil).Once()
 
-		app, err := service.GetApp("the_org_id", "the_app_id")
+		app, err := service.GetApp("the_app_id")
 
 		assert.NoError(t, err)
 		assert.Equal(t, "the_app_id", app.ID)
@@ -122,7 +122,7 @@ func TestGetApp(t *testing.T) {
 			Body:       io.NopCloser(strings.NewReader(`{"error":"app not found"}`)),
 		}, nil).Once()
 
-		_, err := service.GetApp("the_org_id", "missing_app")
+		_, err := service.GetApp("missing_app")
 
 		assert.Error(t, err)
 		mockHTTPClient.AssertExpectations(t)

--- a/internal/appcloud/service_test.go
+++ b/internal/appcloud/service_test.go
@@ -3,7 +3,6 @@ package appcloud
 import (
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 
@@ -14,8 +13,7 @@ import (
 
 func TestNewService(t *testing.T) {
 	t.Run("targets_the_dev_management_api_when_HYPHEN_DEV_is_set", func(t *testing.T) {
-		os.Setenv("HYPHEN_DEV", "true")
-		t.Cleanup(func() { os.Unsetenv("HYPHEN_DEV") })
+		t.Setenv("HYPHEN_DEV", "true")
 
 		service := NewService()
 
@@ -24,7 +22,7 @@ func TestNewService(t *testing.T) {
 	})
 
 	t.Run("targets_the_prod_management_api_by_default", func(t *testing.T) {
-		os.Unsetenv("HYPHEN_DEV")
+		t.Setenv("HYPHEN_DEV", "")
 
 		service := NewService()
 

--- a/internal/appcloud/service_test.go
+++ b/internal/appcloud/service_test.go
@@ -1,0 +1,130 @@
+package appcloud
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Hyphen/cli/pkg/httputil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestNewService(t *testing.T) {
+	t.Run("targets_the_dev_management_api_when_HYPHEN_DEV_is_set", func(t *testing.T) {
+		os.Setenv("HYPHEN_DEV", "true")
+		t.Cleanup(func() { os.Unsetenv("HYPHEN_DEV") })
+
+		service := NewService()
+
+		assert.Equal(t, "https://api.dev-app.hyphen.cloud", service.baseUrl)
+		assert.NotNil(t, service.httpClient)
+	})
+
+	t.Run("targets_the_prod_management_api_by_default", func(t *testing.T) {
+		os.Unsetenv("HYPHEN_DEV")
+
+		service := NewService()
+
+		assert.Equal(t, "https://api.app.hyphen.cloud", service.baseUrl)
+	})
+}
+
+func TestListApps(t *testing.T) {
+	t.Run("returns_the_apps_from_a_single_page", func(t *testing.T) {
+		mockHTTPClient := new(httputil.MockHTTPClient)
+		service := &AppCloudService{baseUrl: "https://api.example.com", httpClient: mockHTTPClient}
+		responseBody := `{
+			"items": [
+				{"id": "the_app_id", "owner": "drew", "name": "the app", "domains": ["the.app.hyphen.cloud"]},
+				{"id": "another_app", "owner": "drew", "name": "another", "domains": []}
+			],
+			"nextCursor": null
+		}`
+		mockHTTPClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(responseBody)),
+		}, nil).Once()
+
+		apps, err := service.ListApps("the_org_id", "the_project_id")
+
+		assert.NoError(t, err)
+		assert.Len(t, apps, 2)
+		assert.Equal(t, "the_app_id", apps[0].ID)
+		assert.Equal(t, []string{"the.app.hyphen.cloud"}, apps[0].Domains)
+		mockHTTPClient.AssertExpectations(t)
+	})
+
+	t.Run("follows_the_cursor_across_pages", func(t *testing.T) {
+		mockHTTPClient := new(httputil.MockHTTPClient)
+		service := &AppCloudService{baseUrl: "https://api.example.com", httpClient: mockHTTPClient}
+		firstPage := `{"items": [{"id": "app_1"}], "nextCursor": "cursor_2"}`
+		secondPage := `{"items": [{"id": "app_2"}], "nextCursor": null}`
+		mockHTTPClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(firstPage)),
+		}, nil).Once()
+		mockHTTPClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(secondPage)),
+		}, nil).Once()
+
+		apps, err := service.ListApps("the_org_id", "")
+
+		assert.NoError(t, err)
+		assert.Len(t, apps, 2)
+		assert.Equal(t, "app_1", apps[0].ID)
+		assert.Equal(t, "app_2", apps[1].ID)
+		mockHTTPClient.AssertExpectations(t)
+	})
+
+	t.Run("returns_an_error_when_the_api_responds_with_a_non_200", func(t *testing.T) {
+		mockHTTPClient := new(httputil.MockHTTPClient)
+		service := &AppCloudService{baseUrl: "https://api.example.com", httpClient: mockHTTPClient}
+		mockHTTPClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusForbidden,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"forbidden"}`)),
+		}, nil).Once()
+
+		apps, err := service.ListApps("the_org_id", "")
+
+		assert.Error(t, err)
+		assert.Nil(t, apps)
+		mockHTTPClient.AssertExpectations(t)
+	})
+}
+
+func TestGetApp(t *testing.T) {
+	t.Run("returns_the_requested_app", func(t *testing.T) {
+		mockHTTPClient := new(httputil.MockHTTPClient)
+		service := &AppCloudService{baseUrl: "https://api.example.com", httpClient: mockHTTPClient}
+		responseBody := `{"id": "the_app_id", "owner": "drew", "name": "the app", "domains": ["the.app.hyphen.cloud"], "activeRevision": "abc123"}`
+		mockHTTPClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(responseBody)),
+		}, nil).Once()
+
+		app, err := service.GetApp("the_org_id", "the_app_id")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "the_app_id", app.ID)
+		assert.Equal(t, "abc123", app.ActiveRevision)
+		mockHTTPClient.AssertExpectations(t)
+	})
+
+	t.Run("returns_an_error_when_the_app_is_not_found", func(t *testing.T) {
+		mockHTTPClient := new(httputil.MockHTTPClient)
+		service := &AppCloudService{baseUrl: "https://api.example.com", httpClient: mockHTTPClient}
+		mockHTTPClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"app not found"}`)),
+		}, nil).Once()
+
+		_, err := service.GetApp("the_org_id", "missing_app")
+
+		assert.Error(t, err)
+		mockHTTPClient.AssertExpectations(t)
+	})
+}

--- a/internal/appcloud/upload.go
+++ b/internal/appcloud/upload.go
@@ -1,0 +1,181 @@
+package appcloud
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"mime"
+	"mime/multipart"
+	"net/textproto"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/Hyphen/cli/pkg/errors"
+)
+
+// skipNames are directory/file names never uploaded (VCS + build noise +
+// macOS metadata). Other dotfiles (`.well-known/...`, `.htaccess`) are kept —
+// they're real deploy artifacts.
+var skipNames = map[string]bool{
+	".git":         true,
+	"node_modules": true,
+	".DS_Store":    true,
+}
+
+type plannedFile struct {
+	abs string
+	rel string // POSIX (/-separated) relative path — the object-store key
+}
+
+// planUploads enumerates `dir` into a stable, sorted upload list.
+func planUploads(dir string) ([]plannedFile, error) {
+	root, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "resolve %s", dir)
+	}
+	var files []plannedFile
+	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if skipNames[info.Name()] {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		relOS, err := filepath.Rel(root, path)
+		if err != nil {
+			return errors.Wrapf(err, "relativize %s", path)
+		}
+		rel := filepath.ToSlash(relOS)
+		files = append(files, plannedFile{abs: path, rel: rel})
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "walk %s", root)
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].rel < files[j].rel })
+	return files, nil
+}
+
+// buildBatch gzips each file and assembles one multipart/form-data body. Each
+// part carries the filename (the relative path), a guessed Content-Type, and
+// Content-Encoding: gzip — the signal management uses to know the part is
+// gzipped. Returns the body, its content type, and raw/gzipped byte totals.
+func buildBatch(files []plannedFile) (*bytes.Buffer, string, int64, int64, error) {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	var raw, gz int64
+	for _, f := range files {
+		data, err := os.ReadFile(f.abs)
+		if err != nil {
+			return nil, "", 0, 0, errors.Wrapf(err, "read %s", f.abs)
+		}
+		raw += int64(len(data))
+		gzipped, err := gzipBytes(data)
+		if err != nil {
+			return nil, "", 0, 0, errors.Wrapf(err, "gzip %s", f.rel)
+		}
+		gz += int64(len(gzipped))
+
+		h := make(textproto.MIMEHeader)
+		h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename=%q`, f.rel))
+		h.Set("Content-Type", contentType(f.rel))
+		h.Set("Content-Encoding", "gzip")
+		part, err := w.CreatePart(h)
+		if err != nil {
+			return nil, "", 0, 0, errors.Wrapf(err, "multipart part for %s", f.rel)
+		}
+		if _, err := part.Write(gzipped); err != nil {
+			return nil, "", 0, 0, errors.Wrapf(err, "write part for %s", f.rel)
+		}
+	}
+	if err := w.Close(); err != nil {
+		return nil, "", 0, 0, errors.Wrap(err, "finalize multipart body")
+	}
+	return &buf, w.FormDataContentType(), raw, gz, nil
+}
+
+// UploadDirectory walks `dir`, gzips every file, and uploads them to `hex` in
+// batches of `batchSize`. Returns the number of files uploaded.
+func UploadDirectory(svc AppCloudServicer, appID, hex, dir string, batchSize int, progress func(msg string)) (int, error) {
+	if batchSize < 1 {
+		return 0, errors.New("batch size must be >= 1")
+	}
+	files, err := planUploads(dir)
+	if err != nil {
+		return 0, err
+	}
+	if len(files) == 0 {
+		return 0, nil
+	}
+	total := len(files)
+	batches := (total + batchSize - 1) / batchSize
+	done := 0
+	var rawTotal, gzTotal int64
+	for b := 0; b < total; b += batchSize {
+		end := b + batchSize
+		if end > total {
+			end = total
+		}
+		chunk := files[b:end]
+		body, ct, raw, gz, err := buildBatch(chunk)
+		if err != nil {
+			return done, err
+		}
+		if _, err := svc.UploadBatch(appID, hex, body, ct); err != nil {
+			// Return the server error as-is: hx's error type shows only the
+			// outermost message, and HandleHTTPError's is the informative one.
+			return done, err
+		}
+		done += len(chunk)
+		rawTotal += raw
+		gzTotal += gz
+		if progress != nil {
+			progress(fmt.Sprintf("  batch %d/%d: %d files, %s → %s gzipped",
+				(b/batchSize)+1, batches, len(chunk), humanBytes(raw), humanBytes(gz)))
+		}
+	}
+	if progress != nil {
+		progress(fmt.Sprintf("uploaded %d files (%s → %s gzipped) across %d batch(es)",
+			done, humanBytes(rawTotal), humanBytes(gzTotal), batches))
+	}
+	return done, nil
+}
+
+func gzipBytes(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(data); err != nil {
+		return nil, err
+	}
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func contentType(rel string) string {
+	if ct := mime.TypeByExtension(filepath.Ext(rel)); ct != "" {
+		return ct
+	}
+	return "application/octet-stream"
+}
+
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for x := n / unit; x >= unit; x /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/internal/appcloud/upload_test.go
+++ b/internal/appcloud/upload_test.go
@@ -1,0 +1,133 @@
+package appcloud
+
+import (
+	"compress/gzip"
+	"io"
+	"mime"
+	"mime/multipart"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlanUploads(t *testing.T) {
+	t.Run("returns_posix_relpaths_sorted_and_skips_noise", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "index.html"), []byte("<h1>hi</h1>"), 0o644))
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "assets"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "assets", "app.js"), []byte("console.log(1)"), 0o644))
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".git", "HEAD"), []byte("ref"), 0o644))
+
+		files, err := planUploads(dir)
+
+		require.NoError(t, err)
+		rels := []string{}
+		for _, f := range files {
+			rels = append(rels, f.rel)
+		}
+		assert.Equal(t, []string{"assets/app.js", "index.html"}, rels)
+	})
+
+	t.Run("keeps_dotfiles_that_are_not_skipped", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, ".well-known"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".well-known", "security.txt"), []byte("x"), 0o644))
+
+		files, err := planUploads(dir)
+
+		require.NoError(t, err)
+		require.Len(t, files, 1)
+		assert.Equal(t, ".well-known/security.txt", files[0].rel)
+	})
+}
+
+func TestBuildBatch(t *testing.T) {
+	t.Run("gzips_each_part_and_sets_content_encoding_and_filename", func(t *testing.T) {
+		dir := t.TempDir()
+		body := []byte("<!doctype html><h1>hello</h1>")
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "index.html"), body, 0o644))
+		files, err := planUploads(dir)
+		require.NoError(t, err)
+
+		buf, contentType, raw, gz, err := buildBatch(files)
+
+		require.NoError(t, err)
+		assert.Equal(t, int64(len(body)), raw)
+		assert.Greater(t, gz, int64(0))
+
+		// Parse the multipart body back and verify the part metadata + that
+		// the payload is genuinely gzip of the original file.
+		_, params, err := mime.ParseMediaType(contentType)
+		require.NoError(t, err)
+		mr := multipart.NewReader(buf, params["boundary"])
+		part, err := mr.NextPart()
+		require.NoError(t, err)
+		assert.Equal(t, "file", part.FormName())
+		assert.Equal(t, "index.html", part.FileName())
+		assert.Equal(t, "gzip", part.Header.Get("Content-Encoding"))
+		assert.Equal(t, "text/html", firstMediaType(t, part.Header.Get("Content-Type")))
+
+		gzr, err := gzip.NewReader(part)
+		require.NoError(t, err)
+		got, err := io.ReadAll(gzr)
+		require.NoError(t, err)
+		assert.Equal(t, body, got)
+	})
+}
+
+func firstMediaType(t *testing.T, ct string) string {
+	t.Helper()
+	mt, _, err := mime.ParseMediaType(ct)
+	require.NoError(t, err)
+	return mt
+}
+
+func TestUploadDirectory(t *testing.T) {
+	t.Run("uploads_all_files_in_a_single_batch", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "index.html"), []byte("a"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "style.css"), []byte("b"), 0o644))
+		stub := &uploadStub{}
+
+		n, err := UploadDirectory(stub, "the_app_id", "abcd1234", dir, 100, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, 2, n)
+		assert.Equal(t, "the_app_id", stub.appID)
+		assert.Equal(t, "abcd1234", stub.hex)
+		assert.Equal(t, 1, stub.calls)
+	})
+
+	t.Run("splits_into_batches_by_batch_size", func(t *testing.T) {
+		dir := t.TempDir()
+		for _, n := range []string{"a", "b", "c"} {
+			require.NoError(t, os.WriteFile(filepath.Join(dir, n+".txt"), []byte(n), 0o644))
+		}
+		stub := &uploadStub{}
+
+		n, err := UploadDirectory(stub, "app", "hex", dir, 2, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, 3, n)
+		assert.Equal(t, 2, stub.calls) // 3 files, batch size 2 => 2 batches
+	})
+}
+
+// uploadStub captures UploadBatch calls; the other methods are unused here.
+type uploadStub struct {
+	AppCloudServicer
+	appID string
+	hex   string
+	calls int
+}
+
+func (u *uploadStub) UploadBatch(appID, hex string, body io.Reader, contentType string) (UploadResponse, error) {
+	u.appID, u.hex = appID, hex
+	u.calls++
+	_, _ = io.Copy(io.Discard, body)
+	return UploadResponse{}, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,9 @@ type Config struct {
 	Project            *ConfigProject `json:"project,omitempty"`
 	AutoUpdateDisabled *bool          `json:"auto_update_disabled,omitempty"`
 	Database           interface{}    `json:"database,omitempty"`
+	// AppCloudAppId is the default AppCloud app used by `hx appcloud` when
+	// an <app-id> argument is omitted (set via `hx appcloud app <id>`).
+	AppCloudAppId *string `json:"appcloud_app_id,omitempty"`
 }
 
 func (c *Config) IsMonorepoProject() bool {

--- a/pkg/apiconf/conf.go
+++ b/pkg/apiconf/conf.go
@@ -37,6 +37,19 @@ func GetBaseAppUrl() string {
 	return "https://app.hyphen.ai"
 }
 
+// GetBaseAppCloudUrl returns the base URL for the AppCloud management API.
+// It mirrors the other services' dev/local/prod switch so that `--dev`
+// (or HYPHEN_DEV=true) targets the AppCloud development environment.
+func GetBaseAppCloudUrl() string {
+	if flags.DevFlag || strings.ToLower(os.Getenv("HYPHEN_DEV")) == "true" {
+		return "https://api.dev-app.hyphen.cloud"
+	}
+	if strings.ToLower(os.Getenv("HYPHEN_Local")) == "true" {
+		return "http://localhost:8080"
+	}
+	return "https://api.app.hyphen.cloud"
+}
+
 func GetBaseAuthUrl() string {
 	if flags.DevFlag || strings.ToLower(os.Getenv("HYPHEN_DEV")) == "true" {
 		return "https://dev-auth.hyphen.ai"

--- a/pkg/httputil/client.go
+++ b/pkg/httputil/client.go
@@ -58,7 +58,10 @@ func (hc *HyphenClient) Do(req *http.Request) (*http.Response, error) {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
-	if req.Body != nil {
+	// Default the body content type to JSON, but never override a caller that
+	// set one explicitly (e.g. multipart/form-data uploads, whose boundary
+	// parameter would otherwise be lost).
+	if req.Body != nil && req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
 


### PR DESCRIPTION
This PR:
- Adds an `appcloud` command group to hx (alias `ac`), porting the AppCloud CLI surface into the Hyphen CLI so sites can be deployed and managed with the same login as everything else in hx.
- Adds **`hx appcloud deploy <name> <dir>`** — the end-to-end flow: create-or-find the app (by its first `--domain`, else by name), register a revision, gzip + multipart-upload the directory in batches, and pin it active. Prints the live URL.
- Adds **`hx appcloud apps`** — `list`, `get <app-id>`, `create <name>`, `delete <app-id>`, `deploy <app-id> <dir>` (ship a revision into an existing app), and `config <get|set>`.
- Adds **`hx appcloud app [app-id]`** — set/show the default app (persisted in `~/.hx` as `appcloud_app_id`); `app config <get|set>` operate on it.
- Adds **`hx appcloud metrics`** — `http` and `errors` (gateway telemetry logs, with `--app`/`--domain`/`--from`/`--to`/`--limit` filters).
- Wires **dev targeting** the same way as apix: `--dev` (or `HYPHEN_DEV=true`) points every call at `api.dev-app.hyphen.cloud` via a new `apiconf.GetBaseAppCloudUrl()`.
- Defaults `--owner` to the logged-in user (member email, falling back to id) — it's an attribution label, not a security principal — so you rarely pass it.
- Follows hx conventions: primary required values are positional (`apps create <name>`, `deploy <name> <dir>`), flags are for the rest.

**Supporting change:** `pkg/httputil` no longer overrides an explicitly-set `Content-Type`, so multipart uploads keep their boundary (JSON callers are unaffected, since they don't set one). Without this, uploads fail with "invalid boundary".

**Gating:** the group is registered behind the `canUseAppcloud` Horizon toggle, same pattern as `deploy`/`build`. It won't appear until that toggle is enabled.

**Auth:** uses hx's existing OAuth login (`hx auth`, `hx auth --dev`); no `login`/`logout` subcommands (unlike the standalone appcloud-cli) since hx already handles that.

**Testing:** unit tests cover the upload planner (dir walk / gzip / multipart with per-part `Content-Encoding`), the service, and the command tree. Verified live end-to-end against dev: `hx --dev appcloud deploy` uploads a real site and the gateway serves it (HTTP 200); `apps`/`app`/`config` all work.
